### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -8,7 +8,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -22,7 +22,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
 
       - name: Build and Test
         run: |
@@ -84,6 +85,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
       - name: Install dependencies on macos
         run: |
           brew reinstall gcc
@@ -111,6 +113,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
 
       - name: Build and Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: 'main'
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: 'main'
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: 'main'
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -80,9 +80,9 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: 'main'
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
 
@@ -64,7 +64,7 @@ jobs:
                                ./gradlew publishToMavenLocal"
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -79,9 +79,9 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
       - name: Install dependencies on macos
@@ -105,10 +105,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
 
@@ -121,7 +121,7 @@ jobs:
           ./gradlew publishToMavenLocal
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,11 +19,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,12 +19,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 17
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Fetch Tag and Version Information
         run: |
           TAG=$(echo "${GITHUB_REF#refs/*/}")
@@ -30,7 +30,7 @@ jobs:
           echo "BASE=$BASE" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.BASE }}
           token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Fetch Tag and Version Information
         run: |
           TAG=$(echo "${GITHUB_REF#refs/*/}")
@@ -30,7 +30,7 @@ jobs:
           echo "BASE=$BASE" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           ref: ${{ env.BASE }}
           token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fetch Tag and Version Information
         run: |
           TAG=$(echo "${GITHUB_REF#refs/*/}")
@@ -30,7 +30,7 @@ jobs:
           echo "BASE=$BASE" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.BASE }}
           token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Fetch Tag and Version Information
         run: |
           TAG=$(echo "${GITHUB_REF#refs/*/}")
@@ -30,7 +30,7 @@ jobs:
           echo "BASE=$BASE" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.BASE }}
           token: ${{ steps.github_app_token.outputs.token }}

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,11 @@ def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
 configurations {
     zipArchive
     all {
-        resolutionStrategy.force "org.mockito:mockito-core:5.5.0"
+        resolutionStrategy {
+            force "org.mockito:mockito-core:5.5.0"
+            force "com.google.guava:guava:32.1.3-jre" // CVE for 31.1
+            force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ configurations {
     zipArchive
     all {
         resolutionStrategy {
-            force "org.mockito:mockito-core:5.5.0"
+            force "org.mockito:mockito-core:5.8.0"
             force "com.google.guava:guava:32.1.3-jre" // CVE for 31.1
             force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
         }
@@ -93,17 +93,17 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
     compileOnly group: 'org.json', name: 'json', version: '20231013'
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
-    implementation("com.google.guava:guava:32.0.1-jre")
+    implementation("com.google.guava:guava:32.1.3-jre")
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation "org.mockito:mockito-core:3.10.0"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-    testImplementation 'org.mockito:mockito-junit-jupiter:3.10.0'
+    testImplementation "org.mockito:mockito-core:5.8.0"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.8.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "com.cronutils:cron-utils:9.1.6"
+    testImplementation "com.cronutils:cron-utils:9.2.1"
     testImplementation "commons-validator:commons-validator:1.7"
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
 }
 
 task extractSqlJar(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -132,12 +132,16 @@ test {
 }
 
 spotless {
-    java {
-        removeUnusedImports()
-        importOrder 'java', 'javax', 'org', 'com'
-        licenseHeaderFile 'spotless.license.java'
-
-        eclipse().configFile rootProject.file('.eclipseformat.xml')
+    if (JavaVersion.current() >= JavaVersion.VERSION_17) {
+        // Spotless configuration for Java files
+        java {
+            removeUnusedImports()
+            importOrder 'java', 'javax', 'org', 'com'
+            licenseHeaderFile 'spotless.license.java'
+            eclipse().configFile rootProject.file('.eclipseformat.xml')
+        }
+    } else {
+        logger.lifecycle("Spotless plugin requires Java 17 or higher. Skipping Spotless tasks.")
     }
 }
 


### PR DESCRIPTION
### Description

Updates dependencies
1. Addresses dependencies or transitive dependencies indicated in CVE-tagged issues by forcing the latest version
    - Note: the required eclipse-core-runtime version bump limits spotless to be run on JDK17+
2. Updates GitHub action versions
    - Note: actions/checkout v4 and actions/setup-java v4 require node20 which is not supported by the Linux containers.
3. Updates junit and mockito versions
 
### Issues Resolved

Fixes #24 
Fixes #25 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
