### PR TITLE
Include ML zip dependency in integTest and run tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import org.opensearch.gradle.test.RestIntegTestTask
+import java.util.concurrent.Callable
+
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.11.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
+        }
     }
 
     repositories {
@@ -104,6 +115,9 @@ dependencies {
     testImplementation "com.cronutils:cron-utils:9.2.1"
     testImplementation "commons-validator:commons-validator:1.8.0"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
+
+    // ZipArchive dependencies used for integration tests
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
 }
 
 task extractSqlJar(type: Copy) {
@@ -203,6 +217,92 @@ publishing {
     }
     gradle.startParameter.setShowStacktrace(ShowStacktrace.ALWAYS)
     gradle.startParameter.setLogLevel(LogLevel.DEBUG)
+}
+
+def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
+opensearch_tmp_dir.mkdirs()
+def _numNodes = findProperty('numNodes') as Integer ?: 1
+
+// Set up integration tests
+task integTest(type: RestIntegTestTask) {
+    description = "Run tests against a cluster"
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+}
+tasks.named("check").configure { dependsOn(integTest) }
+
+integTest {
+
+    dependsOn "bundlePlugin"
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
+    systemProperty('project.root', project.rootDir.absolutePath)
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+
+    // doFirst delays this block until execution time
+    doFirst {
+        // Tell the test JVM if the cluster JVM is running under a debugger so that tests can
+        // use longer timeouts for requests.
+        def isDebuggingCluster = getDebug() || System.getProperty("test.debug") != null
+        systemProperty 'cluster.debug', isDebuggingCluster
+        // Set number of nodes system property to be used in tests
+        systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+        // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+        // not being written, the waitForAllConditions ensures it's written
+        getClusters().forEach { cluster ->
+            cluster.waitForAllConditions()
+        }
+    }
+
+    // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+    }
+}
+
+// Set up integration test clusters, installs all zipArchive dependencies and Flow Framework
+testClusters.integTest {
+    testDistribution = "ARCHIVE"
+
+    // Installs all registered zipArchive dependencies on integTest cluster nodes
+    configurations.zipArchive.asFileTree.each {
+        plugin(provider(new Callable<RegularFile>(){
+            @Override
+            RegularFile call() throws Exception {
+                return new RegularFile() {
+                    @Override
+                    File getAsFile() {
+                        return it
+                    }
+                }
+            }
+        }))
+    }
+
+    // Install Flow Framwork Plugin on integTest cluster nodes
+    plugin(project.tasks.bundlePlugin.archiveFile)
+
+    // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
+    if (_numNodes > 1) numberOfNodes = _numNodes
+
+    // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
+    // i.e. we have to use a custom property to flag when we want to debug OpenSearch JVM
+    // since we also support multi node integration tests we increase debugPort per node
+    if (System.getProperty("opensearch.debug") != null) {
+        def debugPort = 5005
+        nodes.forEach { node ->
+            node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=*:${debugPort}")
+            debugPort += 1
+        }
+    }
+}
+
+// Automatically sets up the integration test cluster locally
+run {
+    useCluster testClusters.integTest
 }
 
 // updateVersion: Task to auto increment to the next development iteration

--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ integTest {
     }
 }
 
-// Set up integration test clusters, installs all zipArchive dependencies and Flow Framework
+// Set up integration test clusters, installs all zipArchive dependencies and this plugin
 testClusters.integTest {
     testDistribution = "ARCHIVE"
 
@@ -282,7 +282,7 @@ testClusters.integTest {
         }))
     }
 
-    // Install Flow Framwork Plugin on integTest cluster nodes
+    // Install skills plugin on integTest cluster nodes
     plugin(project.tasks.bundlePlugin.archiveFile)
 
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "2.11.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
### Description
Uses `zipArchive` to pull an ML plugin zip to use in the `integTest` cluster, and utilized this same cluster when running `./gradlew run`. The impact of this is quicker testing on a local cluster via `./gradlew run` without having to replace zips on a tarball of core OpenSearch, for example.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
