### PR TITLE
add security policy for accessDeclaredMembers

### DIFF
--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+grant {
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+};


### PR DESCRIPTION
### Description
allow `accessDeclaredMembers`
when i run PPL tool in some agent, i get
```
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "accessDeclaredMembers")
        at java.security.AccessControlContext.checkPermission(AccessControlContext.java:485) ~[?:?]
        at java.security.AccessController.checkPermission(AccessController.java:1068) ~[?:?]
        at java.lang.SecurityManager.checkPermission(SecurityManager.java:416) ~[?:?]
        at java.lang.Class.checkMemberAccess(Class.java:3051) ~[?:?]
        at java.lang.Class.getDeclaredConstructor(Class.java:2750) ~[?:?]
        at com.google.gson.internal.ConstructorConstructor.newDefaultConstructor(ConstructorConstructor.java:212) ~[?:?]
        at com.google.gson.internal.ConstructorConstructor.get(ConstructorConstructor.java:120) ~[?:?]
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory.create(CollectionTypeAdapterFactory.java:54) ~[?:?]
        at com.google.gson.Gson.getAdapter(Gson.java:556) ~[?:?]
        at com.google.gson.Gson.toJson(Gson.java:834) ~[?:?]
        at com.google.gson.Gson.toJson(Gson.java:812) ~[?:?]
        at com.google.gson.Gson.toJson(Gson.java:759) ~[?:?]
        at com.google.gson.Gson.toJson(Gson.java:736) ~[?:?]
        at org.opensearch.agent.tools.PPLTool.lambda$extractSamples$9(PPLTool.java:292) ~[?:?]
        at java.security.AccessController.doPrivileged(AccessController.java:569) ~[?:?]
        at org.opensearch.agent.tools.PPLTool.extractSamples(PPLTool.java:292) ~[?:?]
        at org.opensearch.agent.tools.PPLTool.constructTableInfo(PPLTool.java:239) ~[?:?]
        at org.opensearch.agent.tools.PPLTool.lambda$run$5(PPLTool.java:103) ~[?:?]
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
