### PR TITLE
Add a search AD results tool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -70,7 +70,6 @@ public class SearchAnomalyResultsTool implements Tool {
         };
     }
 
-    // TODO: update description
     // Response is currently in a simple string format including the list of anomaly results (only detector ID, grade, confidence),
     // and toal # of results. The output will likely need to be updated, standardized, and include more fields in the
     // future to cover a sufficient amount of potential questions the agent will need to handle.

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -139,8 +139,8 @@ public class SearchAnomalyResultsTool implements Tool {
             sb.append("AnomalyResults=[");
             for (SearchHit hit : hits) {
                 sb.append("{");
-                sb.append("id=").append(hit.getId()).append(",");
-                sb.append("grade=").append(hit.getSourceAsMap().get("anomaly_grade"));
+                sb.append("detectorId=").append(hit.getSourceAsMap().get("detector_id")).append(",");
+                sb.append("grade=").append(hit.getSourceAsMap().get("anomaly_grade")).append(",");
                 sb.append("confidence=").append(hit.getSourceAsMap().get("confidence"));
                 sb.append("}");
             }

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.ad.client.AnomalyDetectionNodeClient;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ToolAnnotation(SearchAnomalyResultsTool.TYPE)
+public class SearchAnomalyResultsTool implements Tool {
+    public static final String TYPE = "SearchAnomalyResultsTool";
+    private static final String DEFAULT_DESCRIPTION = "Use this tool to search anomaly results.";
+
+    @Setter
+    @Getter
+    private String name = TYPE;
+    @Getter
+    @Setter
+    private String description = DEFAULT_DESCRIPTION;
+
+    @Getter
+    private String version;
+
+    private Client client;
+
+    private AnomalyDetectionNodeClient adClient;
+
+    @Setter
+    private Parser<?, ?> inputParser;
+    @Setter
+    private Parser<?, ?> outputParser;
+
+    public SearchAnomalyResultsTool(Client client) {
+        this.client = client;
+        this.adClient = new AnomalyDetectionNodeClient(client);
+
+        // probably keep this overridden output parser. need to ensure the output matches what's expected
+        outputParser = new Parser<>() {
+            @Override
+            public Object parse(Object o) {
+                @SuppressWarnings("unchecked")
+                List<ModelTensors> mlModelOutputs = (List<ModelTensors>) o;
+                return mlModelOutputs.get(0).getMlModelTensors().get(0).getDataAsMap().get("response");
+            }
+        };
+    }
+
+    // TODO: update description
+    // Response is currently in a simple string format including the list of anomaly results (only name and ID attached), and
+    // number of total results. The output will likely need to be updated, standardized, and include more fields in the
+    // future to cover a sufficient amount of potential questions the agent will need to handle.
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        final String detectorId = parameters.getOrDefault("detectorId", null);
+        final Boolean realTime = parameters.containsKey("realTime")
+            ? Boolean.parseBoolean(parameters.get("realTime"))
+            : null;
+        final Boolean anomalyGradeThreshold = parameters.containsKey("anomalyGradeThreshold")
+            ? Boolean.parseBoolean(parameters.get("anomalyGradeThreshold"))
+            : null;
+        final Long dataStartTime = parameters.containsKey("dataStartTime") && StringUtils.isNumeric(parameters.get("dataStartTime"))
+            ? Long.parseLong(parameters.get("dataStartTime"))
+            : null;
+        final Long dataEndTime = parameters.containsKey("dataEndTime") && StringUtils.isNumeric(parameters.get("dataEndTime"))
+            ? Long.parseLong(parameters.get("dataEndTime"))
+            : null;
+        final String sortOrderStr = parameters.getOrDefault("sortOrder", "asc");
+        final SortOrder sortOrder = sortOrderStr.equalsIgnoreCase("asc") ? SortOrder.ASC : SortOrder.DESC;
+        final String sortString = parameters.getOrDefault("sortString", "name.keyword");
+        final int size = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
+        final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
+
+        // TODO: update list below
+        List<QueryBuilder> mustList = new ArrayList<QueryBuilder>();
+        if (detectorName != null) {
+            mustList.add(new TermQueryBuilder("name.keyword", detectorName));
+        }
+        if (detectorNamePattern != null) {
+            mustList.add(new WildcardQueryBuilder("name.keyword", detectorNamePattern));
+        }
+        if (indices != null) {
+            mustList.add(new TermQueryBuilder("indices", indices));
+        }
+        if (highCardinality != null) {
+            mustList.add(new TermQueryBuilder("detector_type", highCardinality ? "MULTI_ENTITY" : "SINGLE_ENTITY"));
+        }
+        if (lastUpdateTime != null) {
+            mustList.add(new BoolQueryBuilder().filter(new RangeQueryBuilder("last_update_time").gte(lastUpdateTime)));
+
+        }
+
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.must().addAll(mustList);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .query(boolQueryBuilder)
+            .size(size)
+            .from(startIndex)
+            .sort(sortString, sortOrder);
+
+        SearchRequest searchDetectorRequest = new SearchRequest().source(searchSourceBuilder);
+
+        ActionListener<SearchResponse> searchAnomalyResultListener = ActionListener.<SearchResponse>wrap(response -> {
+            StringBuilder sb = new StringBuilder();
+            SearchHit[] hits = response.getHits().getHits();
+            sb.append("AnomalyResults=[");
+            for (SearchHit hit : hits) {
+                sb.append("{");
+                sb.append("id=").append(hit.getId()).append(",");
+                sb.append("name=").append(hit.getSourceAsMap().get("name"));
+                sb.append("}");
+            }
+            sb.append("]");
+            sb.append("TotalAnomalyResults=").append(response.getHits().getTotalHits().value);
+            listener.onResponse((T) sb.toString());
+        }, e -> { listener.onFailure(e); });
+
+        adClient.searchAnomalyResults(searchDetectorRequest, searchDetectorListener);
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        return true;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Factory for the {@link SearchAnomalyResultsTool}
+     */
+    public static class Factory implements Tool.Factory<SearchAnomalyResultsTool> {
+        private Client client;
+
+        private AnomalyDetectionNodeClient adClient;
+
+        private static Factory INSTANCE;
+
+        /** 
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (SearchAnomalyResultsTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        /**
+         * Initialize this factory
+         * @param client The OpenSearch client
+         */
+        public void init(Client client) {
+            this.client = client;
+            this.adClient = new AnomalyDetectionNodeClient(client);
+        }
+
+        @Override
+        public SearchAnomalyResultsTool create(Map<String, Object> map) {
+            return new SearchAnomalyResultsTool(client);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -71,7 +71,7 @@ public class SearchAnomalyResultsTool implements Tool {
     }
 
     // Response is currently in a simple string format including the list of anomaly results (only detector ID, grade, confidence),
-    // and toal # of results. The output will likely need to be updated, standardized, and include more fields in the
+    // and total # of results. The output will likely need to be updated, standardized, and include more fields in the
     // future to cover a sufficient amount of potential questions the agent will need to handle.
     @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -8,6 +8,7 @@ package org.opensearch.agent.tools;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -63,6 +65,25 @@ public class SearchAnomalyResultsToolTests {
         nullParams = null;
         emptyParams = Collections.emptyMap();
         nonEmptyParams = Map.of("detectorId", "foo");
+    }
+
+    @Test
+    public void testParseParams() throws Exception {
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+        Map<String, String> validParams = new HashMap<String, String>();
+        validParams.put("detectorId", "foo");
+        validParams.put("realTime", "true");
+        validParams.put("anomalyGradethreshold", "-1");
+        validParams.put("dataStartTime", "1234");
+        validParams.put("dataEndTime", "5678");
+        validParams.put("sortOrder", "AsC");
+        validParams.put("sortString", "foo.bar");
+        validParams.put("size", "10");
+        validParams.put("startIndex", "0");
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        assertDoesNotThrow(() -> tool.run(validParams, listener));
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.agent.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -62,6 +63,15 @@ public class SearchAnomalyResultsToolTests {
         nullParams = null;
         emptyParams = Collections.emptyMap();
         nonEmptyParams = Map.of("detectorId", "foo");
+    }
+
+    @Test
+    public void testRunWithInvalidAnomalyGradeParam() throws Exception {
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        assertThrows(NumberFormatException.class, () -> tool.run(Map.of("anomalyGradeThreshold", "foo"), listener));
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.ClusterAdminClient;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+
+public class SearchAnomalyResultsToolTests {
+    @Mock
+    private NodeClient nodeClient;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+
+    private Map<String, String> nullParams;
+    private Map<String, String> emptyParams;
+    private Map<String, String> nonEmptyParams;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        SearchAnomalyResultsTool.Factory.getInstance().init(nodeClient);
+
+        nullParams = null;
+        emptyParams = Collections.emptyMap();
+        nonEmptyParams = Map.of("detectorId", "foo");
+    }
+
+    @Test
+    public void testRunWithNoResults() throws Exception {
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        SearchHit[] hits = new SearchHit[0];
+
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+
+        SearchResponse getResultsResponse = new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+        String expectedResponseStr = String.format(Locale.getDefault(), "AnomalyResults=[]TotalAnomalyResults=%d", hits.length);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<SearchResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getResultsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithSingleResult() throws Exception {
+        final String detectorId = "detector-1-id";
+        final double anomalyGrade = 0.5;
+        final double confidence = 0.9;
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
+        content.startObject();
+        content.field("detector_id", detectorId);
+        content.field("anomaly_grade", anomalyGrade);
+        content.field("confidence", confidence);
+        content.endObject();
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = new SearchHit(0, detectorId, null, null).sourceRef(BytesReference.bytes(content));
+
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+
+        SearchResponse getResultsResponse = new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+        String expectedResponseStr = String
+            .format(
+                "AnomalyResults=[{detectorId=%s,grade=%2.1f,confidence=%2.1f}]TotalAnomalyResults=%d",
+                detectorId,
+                anomalyGrade,
+                confidence,
+                hits.length
+            );
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            ActionListener<SearchResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getResultsResponse);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testValidate() {
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(SearchAnomalyResultsTool.TYPE, tool.getType());
+        assertTrue(tool.validate(emptyParams));
+        assertTrue(tool.validate(nonEmptyParams));
+        assertTrue(tool.validate(nullParams));
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a search AD results tool. It exposes several different parameters to search and sort the desired results. Note these are subject to change as more integration testing is done with agents configured with the tool.

Testing:
- manually tested the generated queries against a test cluster to ensure they work as expected against different scenarios and different types of anomaly results
- adds limited UT consistent with existing coverage of tools for now. Again this may be improved when the inputs/outputs/parameters become more standardized and we can have more robust coverage and detailed test cases. We can see how the performance is when we benchmark the tools in integration tests with an equipped agent configured with an LLM
 
### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/1548
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
