### PR TITLE
feat: search index tool

### DIFF
--- a/src/main/java/org/opensearch/agent/ToolPlugin.java
+++ b/src/main/java/org/opensearch/agent/ToolPlugin.java
@@ -12,7 +12,9 @@ import java.util.function.Supplier;
 
 import org.opensearch.agent.tools.NeuralSparseSearchTool;
 import org.opensearch.agent.tools.PPLTool;
+import org.opensearch.agent.tools.SearchIndexTool;
 import org.opensearch.agent.tools.VectorDBTool;
+import org.opensearch.agent.tools.SearchIndexTool;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -58,6 +60,7 @@ public class ToolPlugin extends Plugin implements MLCommonsExtension {
         PPLTool.Factory.getInstance().init(client);
         NeuralSparseSearchTool.Factory.getInstance().init(client, xContentRegistry);
         VectorDBTool.Factory.getInstance().init(client, xContentRegistry);
+        SearchIndexTool.Factory.getInstance().init(client, xContentRegistry);
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/opensearch/agent/ToolPlugin.java
+++ b/src/main/java/org/opensearch/agent/ToolPlugin.java
@@ -14,7 +14,6 @@ import org.opensearch.agent.tools.NeuralSparseSearchTool;
 import org.opensearch.agent.tools.PPLTool;
 import org.opensearch.agent.tools.SearchIndexTool;
 import org.opensearch.agent.tools.VectorDBTool;
-import org.opensearch.agent.tools.SearchIndexTool;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -66,6 +66,15 @@ public abstract class AbstractRetrieverTool implements Tool {
 
     protected abstract String getQueryBody(String queryText);
 
+    public static Map<String, Object> processResponse(SearchHit hit) {
+        Map<String, Object> docContent = new HashMap<>();
+        docContent.put("_index", hit.getIndex());
+        docContent.put("_id", hit.getId());
+        docContent.put("_score", hit.getScore());
+        docContent.put("_source", hit.getSourceAsMap());
+        return docContent;
+    }
+
     private <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
         String question = parameters.get(INPUT_FIELD);
         if (StringUtils.isBlank(question)) {
@@ -98,13 +107,8 @@ public abstract class AbstractRetrieverTool implements Tool {
 
             if (hits != null && hits.length > 0) {
                 StringBuilder contextBuilder = new StringBuilder();
-                for (int i = 0; i < hits.length; i++) {
-                    SearchHit hit = hits[i];
-                    Map<String, Object> docContent = new HashMap<>();
-                    docContent.put("_index", hit.getIndex());
-                    docContent.put("_id", hit.getId());
-                    docContent.put("_score", hit.getScore());
-                    docContent.put("_source", hit.getSourceAsMap());
+                for (SearchHit hit : hits) {
+                    Map<String, Object> docContent = processResponse(hit);
                     contextBuilder.append(gson.toJson(docContent)).append("\n");
                 }
                 listener.onResponse((T) contextBuilder.toString());

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -47,7 +47,7 @@ public class SearchIndexTool implements Tool {
 
     public static final String TYPE = "SearchIndexTool";
     private static final String DEFAULT_DESCRIPTION =
-            "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query.";
+        "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query.";
 
     private String name = TYPE;
 
@@ -88,8 +88,8 @@ public class SearchIndexTool implements Tool {
 
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             XContentParser queryParser = XContentType.JSON
-                    .xContent()
-                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
+                .xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
             searchSourceBuilder.parseXContent(queryParser);
             SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
 

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -105,7 +105,7 @@ public class SearchIndexTool implements Tool {
                         });
                         contextBuilder.append(doc).append("\n");
                     }
-                    listener.onResponse((T) StringUtils.gson.toJson(contextBuilder.toString()));
+                    listener.onResponse((T) contextBuilder.toString());
                 } else {
                     listener.onResponse((T) "");
                 }

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools;
+
+import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.ml.common.spi.tools.Tool;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
+import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import com.google.gson.JsonObject;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+@Getter
+@Setter
+@Log4j2
+@ToolAnnotation(SearchIndexTool.TYPE)
+public class SearchIndexTool implements Tool {
+
+    public static final String INPUT_FIELD = "input";
+    public static final String INDEX_FIELD = "index";
+    public static final String QUERY_FIELD = "query";
+
+    public static final String TYPE = "SearchIndexTool";
+    private static final String DEFAULT_DESCRIPTION =
+            "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query.";
+
+    private String name = TYPE;
+
+    private String description = DEFAULT_DESCRIPTION;
+
+    private Client client;
+
+    private NamedXContentRegistry xContentRegistry;
+
+    public SearchIndexTool(Client client, NamedXContentRegistry xContentRegistry) {
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getVersion() {
+        return null;
+    }
+
+    @Override
+    public boolean validate(Map<String, String> parameters) {
+        return parameters != null && parameters.containsKey(INPUT_FIELD) && parameters.get(INPUT_FIELD) != null;
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        try {
+            String input = parameters.get(INPUT_FIELD);
+            JsonObject jsonObject = StringUtils.gson.fromJson(input, JsonObject.class);
+            String index = jsonObject.get(INDEX_FIELD).getAsString();
+            String query = jsonObject.get(QUERY_FIELD).toString();
+            query = "{\"query\": " + query + "}";
+
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            XContentParser queryParser = XContentType.JSON
+                    .xContent()
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
+            searchSourceBuilder.parseXContent(queryParser);
+            SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
+
+            ActionListener<SearchResponse> actionListener = ActionListener.<SearchResponse>wrap(r -> {
+                SearchHit[] hits = r.getHits().getHits();
+
+                if (hits != null && hits.length > 0) {
+                    StringBuilder contextBuilder = new StringBuilder();
+                    for (SearchHit hit : hits) {
+                        String doc = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> {
+                            Map<String, Object> docContent = AbstractRetrieverTool.processResponse(hit);
+                            return StringUtils.gson.toJson(docContent);
+                        });
+                        contextBuilder.append(doc).append("\n");
+                    }
+                    listener.onResponse((T) StringUtils.gson.toJson(contextBuilder.toString()));
+                } else {
+                    listener.onResponse((T) "");
+                }
+            }, e -> {
+                log.error("Failed to search index", e);
+                listener.onFailure(e);
+            });
+
+            // since searching connector and model needs access control, we need
+            // to forward the request corresponding transport action
+            if (Objects.equals(index, ML_CONNECTOR_INDEX)) {
+                client.execute(MLConnectorSearchAction.INSTANCE, searchRequest, actionListener);
+            } else if (Objects.equals(index, ML_MODEL_INDEX)) {
+                client.execute(MLModelSearchAction.INSTANCE, searchRequest, actionListener);
+            } else {
+                client.search(searchRequest, actionListener);
+            }
+        } catch (Exception e) {
+            log.error("Failed to search index", e);
+            listener.onFailure(e);
+        }
+    }
+
+    public static class Factory implements Tool.Factory<SearchIndexTool> {
+
+        private Client client;
+        private static Factory INSTANCE;
+
+        private NamedXContentRegistry xContentRegistry;
+
+        /**
+         * Create or return the singleton factory instance
+         */
+        public static Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (SearchIndexTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new Factory();
+                return INSTANCE;
+            }
+        }
+
+        public void init(Client client, NamedXContentRegistry xContentRegistry) {
+            this.client = client;
+            this.xContentRegistry = xContentRegistry;
+        }
+
+        @Override
+        public SearchIndexTool create(Map<String, Object> params) {
+            return new SearchIndexTool(client, xContentRegistry);
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -5,8 +5,7 @@
 
 package org.opensearch.agent.tools;
 
-import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
-import static org.opensearch.ml.common.CommonValue.ML_MODEL_INDEX;
+import static org.opensearch.ml.common.CommonValue.*;
 
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -25,6 +24,7 @@ import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupSearchAction;
 import org.opensearch.ml.common.utils.StringUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -47,7 +47,7 @@ public class SearchIndexTool implements Tool {
 
     public static final String TYPE = "SearchIndexTool";
     private static final String DEFAULT_DESCRIPTION =
-        "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query.";
+        "Use this tool to search an index by providing two parameters: 'index' for the index name, and 'query' for the OpenSearch DSL formatted query.";
 
     private String name = TYPE;
 
@@ -120,6 +120,8 @@ public class SearchIndexTool implements Tool {
                 client.execute(MLConnectorSearchAction.INSTANCE, searchRequest, actionListener);
             } else if (Objects.equals(index, ML_MODEL_INDEX)) {
                 client.execute(MLModelSearchAction.INSTANCE, searchRequest, actionListener);
+            } else if (Objects.equals(index, ML_MODEL_GROUP_INDEX)) {
+                client.execute(MLModelGroupSearchAction.INSTANCE, searchRequest, actionListener);
             } else {
                 client.search(searchRequest, actionListener);
             }

--- a/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
@@ -98,7 +98,7 @@ public class AbstractRetrieverToolTests {
         future.join();
         assertEquals(
             "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"Company test_mock have a history of 100 years.\"},\"_id\":\"1\",\"_score\":89.2917}\n"
-                + "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"the price of the api is 2$ per invokation\"},\"_id\":\"2\",\"_score\":0.10702579}\n",
+                + "{\"_index\":\"hybrid-index\",\"_source\":{\"passage_text\":\"the price of the api is 2$ per invocation\"},\"_id\":\"2\",\"_score\":0.10702579}\n",
             future.get()
         );
     }

--- a/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
@@ -218,7 +218,7 @@ public class AbstractRetrieverToolTests {
         // Create a mock object of the abstract Factory class
         Client client = mock(Client.class);
         AbstractRetrieverTool.Factory<Tool> factoryMock = new AbstractRetrieverTool.Factory<>() {
-            public PPLTool create(Map<String, Object> params) {
+            public AbstractRetrieverTool create(Map<String, Object> params) {
                 return null;
             }
         };

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.agent.tools;
 
 import static org.junit.Assert.assertEquals;
@@ -32,7 +37,7 @@ import lombok.SneakyThrows;
 
 public class SearchIndexToolTests {
     static public final NamedXContentRegistry TEST_XCONTENT_REGISTRY_FOR_QUERY = new NamedXContentRegistry(
-            new SearchModule(Settings.EMPTY, List.of()).getNamedXContents()
+        new SearchModule(Settings.EMPTY, List.of()).getNamedXContents()
     );
 
     private Client client;
@@ -46,10 +51,10 @@ public class SearchIndexToolTests {
     public void setup() {
         client = mock(Client.class);
         mockedSearchIndexTool = Mockito
-                .mock(
-                        SearchIndexTool.class,
-                        Mockito.withSettings().useConstructor(client, TEST_XCONTENT_REGISTRY_FOR_QUERY).defaultAnswer(Mockito.CALLS_REAL_METHODS)
-                );
+            .mock(
+                SearchIndexTool.class,
+                Mockito.withSettings().useConstructor(client, TEST_XCONTENT_REGISTRY_FOR_QUERY).defaultAnswer(Mockito.CALLS_REAL_METHODS)
+            );
 
         try (InputStream searchResponseIns = SearchIndexTool.class.getResourceAsStream("retrieval_tool_search_response.json")) {
             if (searchResponseIns != null) {
@@ -111,10 +116,10 @@ public class SearchIndexToolTests {
     @SneakyThrows
     public void testRunWithSearchResults() {
         SearchResponse mockedSearchResponse = SearchResponse
-                .fromXContent(
-                        JsonXContent.jsonXContent
-                                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, mockedSearchResponseString)
-                );
+            .fromXContent(
+                JsonXContent.jsonXContent
+                    .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, mockedSearchResponseString)
+            );
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(mockedSearchResponse);

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -5,13 +5,15 @@
 
 package org.opensearch.agent.tools;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.opensearch.agent.tools.AbstractRetrieverTool.DEFAULT_DESCRIPTION;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -29,6 +31,7 @@ import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
 import org.opensearch.search.SearchModule;
@@ -160,5 +163,11 @@ public class SearchIndexToolTests {
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(ParsingException.class);
         // since error message for ParsingException is different, we only need to expect ParsingException to be thrown
         verify(listener).onFailure(argumentCaptor.capture());
+    }
+
+    @Test
+    public void testFactory() {
+        SearchIndexTool searchIndexTool = SearchIndexTool.Factory.getInstance().create(Collections.emptyMap());
+        assertEquals(SearchIndexTool.TYPE, searchIndexTool.getType());
     }
 }

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -6,14 +6,11 @@
 package org.opensearch.agent.tools;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.opensearch.agent.tools.AbstractRetrieverTool.DEFAULT_DESCRIPTION;
 
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +28,6 @@ import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
 import org.opensearch.search.SearchModule;

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -1,0 +1,159 @@
+package org.opensearch.agent.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
+import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.search.SearchModule;
+
+import lombok.SneakyThrows;
+
+public class SearchIndexToolTests {
+    static public final NamedXContentRegistry TEST_XCONTENT_REGISTRY_FOR_QUERY = new NamedXContentRegistry(
+            new SearchModule(Settings.EMPTY, List.of()).getNamedXContents()
+    );
+
+    private Client client;
+
+    private SearchIndexTool mockedSearchIndexTool;
+
+    private String mockedSearchResponseString;
+
+    @Before
+    @SneakyThrows
+    public void setup() {
+        client = mock(Client.class);
+        mockedSearchIndexTool = Mockito
+                .mock(
+                        SearchIndexTool.class,
+                        Mockito.withSettings().useConstructor(client, TEST_XCONTENT_REGISTRY_FOR_QUERY).defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                );
+
+        try (InputStream searchResponseIns = SearchIndexTool.class.getResourceAsStream("retrieval_tool_search_response.json")) {
+            if (searchResponseIns != null) {
+                mockedSearchResponseString = new String(searchResponseIns.readAllBytes());
+            }
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetType() {
+        String type = mockedSearchIndexTool.getType();
+        assertFalse(Strings.isNullOrEmpty(type));
+        assertEquals("SearchIndexTool", type);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidate() {
+        Map<String, String> parameters = Map.of("input", "{}");
+        assertTrue(mockedSearchIndexTool.validate(parameters));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidateWithEmptyInput() {
+        Map<String, String> parameters = Map.of();
+        assertFalse(mockedSearchIndexTool.validate(parameters));
+    }
+
+    @Test
+    public void testRunWithNormalIndex() {
+        String inputString = "{\"index\": \"test-index\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, times(1)).search(any(), any());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testRunWithConnectorIndex() {
+        String inputString = "{\"index\": \".plugins-ml-connector\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
+    public void testRunWithModelIndex() {
+        String inputString = "{\"index\": \".plugins-ml-model\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testRunWithSearchResults() {
+        SearchResponse mockedSearchResponse = SearchResponse
+                .fromXContent(
+                        JsonXContent.jsonXContent
+                                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, mockedSearchResponseString)
+                );
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mockedSearchResponse);
+            return null;
+        }).when(client).search(any(), any());
+
+        String inputString = "{\"index\": \"test-index\", \"query\": {\"match_all\": {}}}";
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        ActionListener<String> listener = ActionListener.wrap(r -> { future.complete(r); }, e -> { future.completeExceptionally(e); });
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, listener);
+
+        future.join();
+
+        Mockito.verify(client, times(1)).search(any(), any());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testRunWithEmptyQuery() {
+        String inputString = "{\"index\": \"test_index\"}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        ActionListener<String> listener = mock(ActionListener.class);
+        mockedSearchIndexTool.run(parameters, listener);
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+        Mockito.verify(client, Mockito.never()).search(any(), any());
+    }
+
+    @Test
+    public void testRunWithInvalidQuery() {
+        String inputString = "{\"index\": \"test-index\", \"query\": \"invalid query\"}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        ActionListener<String> listener = mock(ActionListener.class);
+        mockedSearchIndexTool.run(parameters, listener);
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+        Mockito.verify(client, Mockito.never()).search(any(), any());
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(ParsingException.class);
+        // since error message for ParsingException is different, we only need to expect ParsingException to be thrown
+        verify(listener).onFailure(argumentCaptor.capture());
+    }
+}

--- a/src/test/resources/org/opensearch/agent/tools/retrieval_tool_search_response.json
+++ b/src/test/resources/org/opensearch/agent/tools/retrieval_tool_search_response.json
@@ -27,7 +27,7 @@
         "_id": "2",
         "_score": 0.10702579,
         "_source": {
-          "passage_text": "the price of the api is 2$ per invokation"
+          "passage_text": "the price of the api is 2$ per invocation"
         }
       }
     ]


### PR DESCRIPTION
### Description

Implement SearchIndexTool to support agent framework. It takes in two string parameters: index and query. Here is the sample usage of this tool. Please remember to replace the model id and agent id.

```
POST /_plugins/_ml/agents/_register
{
  "name": "Test_Agent_For_ReAct",
  "type": "conversational",
  "description": "this is a test agent",
  "llm": {
    "model_id": "xxxxx",
    "parameters": {
      "max_iteration": 10,
      "stop_when_no_tool_found": true,
      "response_filter": "$.completion"
    }
  },
  "memory": {
    "type": "conversation_index"
  },
  "tools": [
    {
      "type": "SearchIndexTool",
      "description": "Use this tool to search index with a query. You should pass in two parameters: index and query. Index is the index name and the query is an OpenSearch DSL query."
    }
  ],
  "app_type": "my app"
}


POST /_plugins/_ml/agents/xxxxx/_execute
{
  "parameters": {
    "question": "Show me all the name field of all documents in index .plugins-ml-agent",
    "verbose": true
  }
}
```

The expected successful response should be 

```
{
  "inference_results": [
    {
      "output": [
        {
          "name": "memory_id",
          "result": "xxxxx"
        },
        {
          "name": "response",
          "result": "Thought: To get the name field of documents in the .plugins-ml-agent index, I should search that index using the SearchIndexTool."
        },
        {
          "name": "response",
          "result": "\nObservation: \"{\\\"_index\\\":\\\".plugins-ml-agent\\\",\\\"_source\\\":{\\\"name\\\":\\\"Test_Agent_For_ReAct\\\"},\\\"_id\\\":\\\"xxxxx\\\",\\\"_score\\\":1.0}\\n\""
        },
        {
          "name": "response",
          "result": "Based on the information I was previously provided from searching the index, the name field of the documents in the .plugins-ml-agent index contains 'Test_Agent_For_ReAct'."
        },
        {
          "name": "response",
          "result": "The name field of the documents in the .plugins-ml-agent index is 'Test_Agent_For_ReAct'."
        }
      ]
    }
  ]
}
```

If there is error when parsing the input, the expected error response could be:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "[query] is null or empty, can not process it."
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "[query] is null or empty, can not process it."
  },
  "status": 400
}
```

### Issues Resolved

1. Implement search index tool
2. Fix bugs in unit tests
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
