### PR TITLE
Fix backport branch name is not correct

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,6 +9,16 @@ on:
 jobs:
   backport:
     runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
     permissions:
       contents: write
       pull-requests: write
@@ -26,6 +36,6 @@ jobs:
         uses: VachaShah/backport@v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>
           labels_template: "<%= JSON.stringify([...labels, 'autocut']) %>"
           failure_labels: "failed backport"


### PR DESCRIPTION
### Description
The correct backport branch name should be something like `backport/backport-41-to-2.x`
otherwise, backport branch will not get deleted when merged by [`delete_backport_branch`](https://github.com/opensearch-project/skills/blob/main/.github/workflows/delete_backport_branch.yml#L10) workflow


 
### Issues Resolved

An example of wrong backportn name PR https://github.com/opensearch-project/skills/pull/68
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
