### PR TITLE
Change js to jar dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ dependencies {
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"
+    //JS plugin is published to `org/opensearch` instead of `org/opensearch/plugin` under local maven repo: https://mvnrepository.com/artifact/org.opensearch/opensearch-job-scheduler.
     zipArchive group: 'org.opensearch', name:'opensearch-job-scheduler', version: "${version}"
     zipArchive "org.opensearch.plugin:opensearch-anomaly-detection:${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.pluginzip'
 
 def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
-def adJarDirectory = "$buildDir/dependencies/opensearch-time-series-analytics"
 
 configurations {
     zipArchive
@@ -90,10 +89,6 @@ task addJarsToClasspath(type: Copy) {
     }
     into("$buildDir/classes")
 
-    from(fileTree(dir: adJarDirectory)) {
-        include "opensearch-time-series-analytics-${version}.jar"
-    }
-    into("$buildDir/classes")
 }
 
 dependencies {
@@ -108,7 +103,8 @@ dependencies {
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
     implementation group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
-    implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
+    implementation group: 'org.opensearch', name: 'opensearch-time-series-analytics', version: "${version}"
+//    implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
 
@@ -138,15 +134,7 @@ task extractSqlJar(type: Copy) {
     into sqlJarDirectory
 }
 
-task extractAdJar(type: Copy) {
-    mustRunAfter()
-    from(zipTree(configurations.zipArchive.find { it.name.startsWith("opensearch-anomaly-detection")}))
-    into adJarDirectory
-}
-
 tasks.addJarsToClasspath.dependsOn(extractSqlJar)
-tasks.addJarsToClasspath.dependsOn(extractJsJar)
-tasks.addJarsToClasspath.dependsOn(extractAdJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
@@ -190,8 +178,6 @@ spotless {
 
 compileJava {
     dependsOn extractSqlJar
-    dependsOn extractJsJar
-    dependsOn extractAdJar
     dependsOn delombok
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ tasks.addJarsToClasspath.dependsOn(extractJsJar)
 tasks.addJarsToClasspath.dependsOn(extractAdJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
+tasks.publishNebulaPublicationToStagingRepository.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
 
 dependencyLicenses.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.pluginzip'
 
 def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
+def adJarDirectory = "$buildDir/dependencies/opensearch-time-series-analytics"
 
 configurations {
     zipArchive
@@ -91,6 +92,10 @@ task addJarsToClasspath(type: Copy) {
     }
     into("$buildDir/classes")
 
+    from(fileTree(dir: adJarDirectory)) {
+        include "opensearch-time-series-analytics-${version}.jar"
+    }
+    into("$buildDir/classes")
 }
 
 dependencies {
@@ -105,8 +110,9 @@ dependencies {
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
     implementation group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
-    implementation group: 'org.opensearch', name: 'opensearch-time-series-analytics', version: "${version}"
-//    implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
+//    implementation group: 'org.opensearch', name: 'opensearch-time-series-analytics', version: "${version}"
+    //TODO change this to jar dependency once ad successfully published main branch jars.
+    implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
 
@@ -136,7 +142,14 @@ task extractSqlJar(type: Copy) {
     into sqlJarDirectory
 }
 
+task extractAdJar(type: Copy) {
+    mustRunAfter()
+    from(zipTree(configurations.zipArchive.find { it.name.startsWith("opensearch-anomaly-detection")}))
+    into adJarDirectory
+}
+
 tasks.addJarsToClasspath.dependsOn(extractSqlJar)
+tasks.addJarsToClasspath.dependsOn(extractAdJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
@@ -180,6 +193,7 @@ spotless {
 
 compileJava {
     dependsOn extractSqlJar
+    dependsOn extractAdJar
     dependsOn delombok
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,6 @@ tasks.addJarsToClasspath.dependsOn(extractJsJar)
 tasks.addJarsToClasspath.dependsOn(extractAdJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
-tasks.publishNebulaPublicationToStagingRepository.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
 
 dependencyLicenses.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,6 @@ configurations {
             force "org.mockito:mockito-core:${versions.mockito}"
             force "com.google.guava:guava:33.0.0-jre" // CVE for 31.1
             force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
-            force "com.google.code.gson:gson:2.10.1"
-            force "org.apache.commons:commons-lang3:3.13.0"
         }
     }
 }
@@ -111,7 +109,7 @@ dependencies {
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
     implementation group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
 //    implementation group: 'org.opensearch', name: 'opensearch-time-series-analytics', version: "${version}"
-    //TODO change this to jar dependency once ad successfully published main branch jars.
+    //TODO change this to jar dependency once ad successfully published jars.
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ configurations {
             force "org.mockito:mockito-core:${versions.mockito}"
             force "com.google.guava:guava:33.0.0-jre" // CVE for 31.1
             force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
+            force "com.google.code.gson:gson:2.10.1"
+            force "org.apache.commons:commons-lang3:3.13.0"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.pluginzip'
 
 def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
-def jsJarDirectory = "$buildDir/dependencies/opensearch-job-scheduler"
 def adJarDirectory = "$buildDir/dependencies/opensearch-time-series-analytics"
 
 configurations {
@@ -91,11 +90,6 @@ task addJarsToClasspath(type: Copy) {
     }
     into("$buildDir/classes")
 
-    from(fileTree(dir: jsJarDirectory)) {
-        include "opensearch-job-scheduler-${version}.jar"
-    }
-    into("$buildDir/classes")
-
     from(fileTree(dir: adJarDirectory)) {
         include "opensearch-time-series-analytics-${version}.jar"
     }
@@ -113,15 +107,13 @@ dependencies {
 
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
-    implementation fileTree(dir: jsJarDirectory, include: ["opensearch-job-scheduler-${version}.jar"])
+    implementation group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"
-    //JS plugin is published to `org/opensearch` instead of `org/opensearch/plugin` under local maven repo: https://mvnrepository.com/artifact/org.opensearch/opensearch-job-scheduler.
-    zipArchive group: 'org.opensearch', name:'opensearch-job-scheduler', version: "${version}"
     zipArchive "org.opensearch.plugin:opensearch-anomaly-detection:${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
 
@@ -144,12 +136,6 @@ task extractSqlJar(type: Copy) {
     mustRunAfter()
     from(zipTree(configurations.zipArchive.find { it.name.startsWith("opensearch-sql-plugin")}))
     into sqlJarDirectory
-}
-
-task extractJsJar(type: Copy) {
-    mustRunAfter()
-    from(zipTree(configurations.zipArchive.find { it.name.startsWith("opensearch-job-scheduler")}))
-    into jsJarDirectory
 }
 
 task extractAdJar(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,6 @@ dependencies {
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"
-    //JS plugin is published to `org/opensearch` instead of `org/opensearch/plugin` under local maven repo: https://mvnrepository.com/artifact/org.opensearch/opensearch-job-scheduler.
     zipArchive group: 'org.opensearch', name:'opensearch-job-scheduler', version: "${version}"
     zipArchive "org.opensearch.plugin:opensearch-anomaly-detection:${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"


### PR DESCRIPTION
### Description
There're two types of dependency in our repo: `on jar` which usually under `org.opensearch`: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/ and `on plugin` which usually under `org.opensearch.plugin`: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/. 
For most common cases, we should depend on jars instead of plugins, because depend on plugin is a workaround and depend on jar is the most natural way.

We're depending on sql's plugin because sql doesn't publish jars for `ppl.jar` and `protocol.jar` and sql team refused to publish these jars, so we have to extract them from sql plugin zip.

Job-scheduler publishes jars to this location: `org.opensearch:opensearch-job-scheduler-${version}`: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/opensearch-job-scheduler/, so we can depend on jar directly. This PR is to make this change.

For Anomaly-detection, the jars also not published to `org.opensearch`: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/ , and the reason I assume is missing publishAllPublicationsToStagingRepository in scripts/build.sh, for now to not break compilation,
we can only extracting jars from ad plugin. If ad in the future publishes jars to sonatype, we can change ad's dependency to jar's approach just like job-scheduler.

For forced versions: I published ad jars in my local so I can change ad dependency to jar type but found there's jar version conflicts, so forced the versions, after publish the PR, I found ad jars are not in sonatype, so rolled back ad to plugin dependency but didn't remove this force version. I've update this part to remove them.

### Issues Resolved
Change js to jar dependency
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
