### PR TITLE
Fix jar hell on failureaccess-1.0.1.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
-    implementation group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
+    compileOnly group: 'org.opensearch', name: 'opensearch-job-scheduler', version: "${version}"
 //    implementation group: 'org.opensearch', name: 'opensearch-time-series-analytics', version: "${version}"
     //TODO change this to jar dependency once ad successfully published jars.
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])


### PR DESCRIPTION


### Description
Fix jar hell on /Users/zaniu/Downloads/opensearch-3.0.0-SNAPSHOT/plugins/.installing-17217627975867998583/failureaccess-1.0.1.jar
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
