### PR TITLE
[Backport 2.x] Fix IT run error by adding job-scheduler back to zipArchive dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ configurations {
     all {
         resolutionStrategy {
             force "org.mockito:mockito-core:${versions.mockito}"
-            force "com.google.guava:guava:32.1.3-jre" // CVE for 31.1
+            force "com.google.guava:guava:33.0.0-jre" // CVE for 31.1
             force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
         }
     }
@@ -108,7 +108,7 @@ dependencies {
     compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     compileOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.22.0"
     compileOnly group: 'org.json', name: 'json', version: '20231013'
-    compileOnly("com.google.guava:guava:32.1.3-jre")
+    compileOnly("com.google.guava:guava:33.0.0-jre")
     compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
@@ -122,8 +122,7 @@ dependencies {
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"
-    //JS plugin is published to `org/opensearch` instead of `org/opensearch/plugin` under local maven repo: https://mvnrepository.com/artifact/org.opensearch/opensearch-job-scheduler.
-    zipArchive group: 'org.opensearch', name:'opensearch-job-scheduler', version: "${version}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${version}"
     zipArchive "org.opensearch.plugin:opensearch-anomaly-detection:${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
 


### PR DESCRIPTION
### Description
Fix IT run error by adding job-scheduler back to zipArchive dependency
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
