### PR TITLE
Integrate search detectors tool with profile API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,8 @@ dependencies {
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${version}"
+
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -138,9 +138,6 @@ public class SearchAnomalyDetectorsTool implements Tool {
 
             // If we need to filter by detector state, make subsequent profile API calls to each detector
             if (running != null || disabled != null || failed != null) {
-
-                // Send out individual AD client calls to fetch detector profiles, continuously adding to a
-                // tracked list of CompletableFutures
                 List<CompletableFuture<GetAnomalyDetectorResponse>> profileFutures = new ArrayList<>();
                 for (SearchHit hit : hits) {
                     CompletableFuture<GetAnomalyDetectorResponse> profileFuture = new CompletableFuture<>();
@@ -166,9 +163,6 @@ public class SearchAnomalyDetectorsTool implements Tool {
                     );
                     adClient.getDetectorProfile(profileRequest, profileListener);
                 }
-
-                // Wait for all CompletableFutures to complete, and iterate through the responses. Filter out
-                // detectors with unwanted detector states.
                 CompletableFuture<List<GetAnomalyDetectorResponse>> listFuture = CompletableFuture
                     .allOf(profileFutures.toArray(new CompletableFuture<?>[0]))
                     .thenApply(v -> profileFutures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
@@ -194,7 +188,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
                                 detectorState = DetectorStateString.Failed.name();
                             } else {
                                 // Task states may fall under other values, such as "FEATURE_REQUIRED" / "STOPPED" / etc.
-                                // We assume here that these will all fall under the disabled category
+                                // Defaulting all other states to fall under the disabled category
                                 detectorState = DetectorStateString.Disabled.name();
                             }
                         } else {

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools.utils;
+
+public class ToolConstants {
+    public static enum DetectorStateString {
+        Running,
+        Disabled,
+        Failed,
+        Initializing
+    }
+}

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -8,7 +8,8 @@ package org.opensearch.agent.tools.utils;
 public class ToolConstants {
     // Detector state is not cleanly defined on the backend plugin. So, we persist a standard
     // set of states here for users to interface with when fetching and filtering detectors.
-    // This follows what frontend AD users are familiar with, as we use the same backend parsing logic.
+    // This follows what frontend AD users are familiar with, as we use the same parsing logic
+    // in SearchAnomalyDetectorsTool.
     public static enum DetectorStateString {
         Running,
         Disabled,

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -6,6 +6,9 @@
 package org.opensearch.agent.tools.utils;
 
 public class ToolConstants {
+    // Detector state is not cleanly defined on the backend plugin. So, we persist a standard
+    // set of states here for users to interface with when fetching and filtering detectors.
+    // This follows what frontend AD users are familiar with, as we use the same backend parsing logic.
     public static enum DetectorStateString {
         Running,
         Disabled,

--- a/src/test/java/org/opensearch/agent/TestHelpers.java
+++ b/src/test/java/org/opensearch/agent/TestHelpers.java
@@ -43,8 +43,10 @@ public class TestHelpers {
 
     public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorIds, String[] detectorStates) {
         AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
+        // For each subsequent call to getId(), return the next detectorId in the array
         when(detector.getId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
         ADTask realtimeAdTask = Mockito.mock(ADTask.class);
+        // For each subsequent call to getState(), return the next detectorState in the array
         when(realtimeAdTask.getState()).thenReturn(detectorStates[0], Arrays.copyOfRange(detectorStates, 1, detectorStates.length));
         GetAnomalyDetectorResponse getDetectorProfileResponse = Mockito.mock(GetAnomalyDetectorResponse.class);
         when(getDetectorProfileResponse.getRealtimeAdTask()).thenReturn(realtimeAdTask);

--- a/src/test/java/org/opensearch/agent/TestHelpers.java
+++ b/src/test/java/org/opensearch/agent/TestHelpers.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.lucene.search.TotalHits;
+import org.mockito.Mockito;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.ad.model.ADTask;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+
+public class TestHelpers {
+
+    public static SearchResponse generateSearchResponse(SearchHit[] hits) {
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+        return new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+    }
+
+    public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorIds, String[] detectorStates) {
+        AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
+        when(detector.getId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
+        ADTask realtimeAdTask = Mockito.mock(ADTask.class);
+        when(realtimeAdTask.getState()).thenReturn(detectorStates[0], Arrays.copyOfRange(detectorStates, 1, detectorStates.length));
+        GetAnomalyDetectorResponse getDetectorProfileResponse = Mockito.mock(GetAnomalyDetectorResponse.class);
+        when(getDetectorProfileResponse.getRealtimeAdTask()).thenReturn(realtimeAdTask);
+        when(getDetectorProfileResponse.getDetector()).thenReturn(detector);
+        return getDetectorProfileResponse;
+    }
+
+    public static SearchHit generateSearchDetectorHit(String detectorName, String detectorId) throws IOException {
+        XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
+        content.startObject();
+        content.field("name", detectorName);
+        content.endObject();
+        return new SearchHit(0, detectorId, null, null).sourceRef(BytesReference.bytes(content));
+    }
+}

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -7,17 +7,17 @@ package org.opensearch.agent.tools;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -26,10 +26,11 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchResponseSections;
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.ClusterAdminClient;
-import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.ad.transport.GetAnomalyDetectorAction;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
+import org.opensearch.agent.TestHelpers;
+import org.opensearch.agent.tools.utils.ToolConstants.DetectorStateString;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
@@ -37,18 +38,10 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.search.SearchHit;
-import org.opensearch.search.SearchHits;
-import org.opensearch.search.aggregations.Aggregations;
 
 public class SearchAnomalyDetectorsToolTests {
     @Mock
     private NodeClient nodeClient;
-    @Mock
-    private AdminClient adminClient;
-    @Mock
-    private IndicesAdminClient indicesAdminClient;
-    @Mock
-    private ClusterAdminClient clusterAdminClient;
 
     private Map<String, String> nullParams;
     private Map<String, String> emptyParams;
@@ -67,22 +60,8 @@ public class SearchAnomalyDetectorsToolTests {
     @Test
     public void testRunWithNoDetectors() throws Exception {
         Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
-
-        SearchHit[] hits = new SearchHit[0];
-
-        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
-
-        SearchResponse getDetectorsResponse = new SearchResponse(
-            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
-            null,
-            0,
-            0,
-            0,
-            0,
-            null,
-            null
-        );
-        String expectedResponseStr = String.format(Locale.getDefault(), "AnomalyDetectors=[]TotalAnomalyDetectors=%d", hits.length);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(new SearchHit[0]);
+        String expectedResponseStr = String.format(Locale.getDefault(), "AnomalyDetectors=[]TotalAnomalyDetectors=0");
 
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
@@ -111,19 +90,7 @@ public class SearchAnomalyDetectorsToolTests {
         content.endObject();
         SearchHit[] hits = new SearchHit[1];
         hits[0] = new SearchHit(0, detectorId, null, null).sourceRef(BytesReference.bytes(content));
-
-        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
-
-        SearchResponse getDetectorsResponse = new SearchResponse(
-            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
-            null,
-            0,
-            0,
-            0,
-            0,
-            null,
-            null
-        );
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         String expectedResponseStr = String
             .format("AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, hits.length);
 
@@ -143,11 +110,212 @@ public class SearchAnomalyDetectorsToolTests {
     }
 
     @Test
+    public void testRunWithRunningDetectorTrue() throws Exception {
+        final String detectorName = "detector-1";
+        final String detectorId = "detector-1-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+        String expectedResponseStr = String
+            .format("AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, hits.length);
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("running", "true"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithRunningDetectorFalse() throws Exception {
+        final String detectorName = "detector-1";
+        final String detectorId = "detector-1-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+        String expectedResponseStr = "AnomalyDetectors=[]TotalAnomalyDetectors=0";
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("running", "false"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithRunningDetectorUndefined() throws Exception {
+        final String detectorName = "detector-1";
+        final String detectorId = "detector-1-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[1];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+        String expectedResponseStr = String
+            .format("AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, hits.length);
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("foo", "bar"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testRunWithCombinedDetectorStatesTrue() throws Exception {
+        final String detectorName1 = "detector-1";
+        final String detectorId1 = "detector-1-id";
+        final String detectorName2 = "detector-2";
+        final String detectorId2 = "detector-2-id";
+        final String detectorName3 = "detector-3";
+        final String detectorId3 = "detector-3-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[3];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName1, detectorId1);
+        hits[1] = TestHelpers.generateSearchDetectorHit(detectorName2, detectorId2);
+        hits[2] = TestHelpers.generateSearchDetectorHit(detectorName3, detectorId3);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(
+                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
+            );
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("running", "true", "disabled", "true", "failed", "true"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().contains("TotalAnomalyDetectors=3"));
+    }
+
+    @Test
+    public void testRunWithCombinedDetectorStatesFalse() throws Exception {
+        final String detectorName1 = "detector-1";
+        final String detectorId1 = "detector-1-id";
+        final String detectorName2 = "detector-2";
+        final String detectorId2 = "detector-2-id";
+        final String detectorName3 = "detector-3";
+        final String detectorId3 = "detector-3-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[3];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName1, detectorId1);
+        hits[1] = TestHelpers.generateSearchDetectorHit(detectorName2, detectorId2);
+        hits[2] = TestHelpers.generateSearchDetectorHit(detectorName3, detectorId3);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(
+                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
+            );
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("running", "false", "disabled", "false", "failed", "false"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().contains("TotalAnomalyDetectors=0"));
+    }
+
+    @Test
+    public void testRunWithCombinedDetectorStatesMixed() throws Exception {
+        final String detectorName1 = "detector-1";
+        final String detectorId1 = "detector-1-id";
+        final String detectorName2 = "detector-2";
+        final String detectorId2 = "detector-2-id";
+        final String detectorName3 = "detector-3";
+        final String detectorId3 = "detector-3-id";
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        // Generate mock values and responses
+        SearchHit[] hits = new SearchHit[3];
+        hits[0] = TestHelpers.generateSearchDetectorHit(detectorName1, detectorId1);
+        hits[1] = TestHelpers.generateSearchDetectorHit(detectorName2, detectorId2);
+        hits[2] = TestHelpers.generateSearchDetectorHit(detectorName3, detectorId3);
+        SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
+        GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
+            .generateGetAnomalyDetectorResponses(
+                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
+            );
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
+
+        tool.run(Map.of("running", "true", "disabled", "false", "failed", "true"), listener);
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener, times(1)).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().contains("TotalAnomalyDetectors=2"));
+    }
+
+    @Test
+    public void testParseParams() throws Exception {
+        Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
+        Map<String, String> validParams = new HashMap<String, String>();
+        validParams.put("detectorName", "foo");
+        validParams.put("indices", "foo");
+        validParams.put("highCardinality", "false");
+        validParams.put("lastUpdateTime", "1234");
+        validParams.put("sortOrder", "foo");
+        validParams.put("size", "10");
+        validParams.put("startIndex", "0");
+        validParams.put("running", "false");
+        validParams.put("disabled", "false");
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+        assertDoesNotThrow(() -> tool.run(validParams, listener));
+        assertDoesNotThrow(() -> tool.run(Map.of("detectorNamePattern", "foo*"), listener));
+        assertDoesNotThrow(() -> tool.run(Map.of("sortOrder", "AsC"), listener));
+    }
+
+    @Test
     public void testValidate() {
         Tool tool = SearchAnomalyDetectorsTool.Factory.getInstance().create(Collections.emptyMap());
         assertEquals(SearchAnomalyDetectorsTool.TYPE, tool.getType());
         assertTrue(tool.validate(emptyParams));
         assertTrue(tool.validate(nonEmptyParams));
         assertTrue(tool.validate(nullParams));
+    }
+
+    private void mockProfileApiCalls(SearchResponse getDetectorsResponse, GetAnomalyDetectorResponse getDetectorProfileResponse) {
+        // Mock return from initial search call
+        doAnswer((invocation) -> {
+            ActionListener<SearchResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getDetectorsResponse);
+            return null;
+        }).when(nodeClient).execute(any(SearchAnomalyDetectorAction.class), any(), any());
+
+        // Mock return from secondary detector profile call
+        doAnswer((invocation) -> {
+            ActionListener<GetAnomalyDetectorResponse> responseListener = invocation.getArgument(2);
+            responseListener.onResponse(getDetectorProfileResponse);
+            return null;
+        }).when(nodeClient).execute(any(GetAnomalyDetectorAction.class), any(), any());
     }
 }

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -228,7 +228,7 @@ public class SearchAnomalyDetectorsToolTests {
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(emptyParams, listener);
+        tool.run(Map.of("running", "false"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         assertEquals(expectedResponseStr, responseCaptor.getValue());


### PR DESCRIPTION
### Description
Adds integration with the AD client's new `getDetectorProfile()` method to fetch detailed detector information. It is used in the context of this tool by allowing filtering by detector state - specifically `running`/`disabled`/`failed`. If the user specifies any of these params, the tool will make further transport action calls via `getDetectorProfile()` to fetch the real-time detector state, and include/exclude based on users setting params to `true`/`false`, respectively.

This also unlocks the tool's future capabilities to query things like historical tasks, fine-grained high-cardinality details, initialization progress, error state, etc.

Adds tests to cover the different combinations of state-related params and expected results.

NOTE: the job-scheduler SPI was added as a dependency to resolve classloading issues regarding job-related fields in the `AnomalyDetector` class.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
