### PR TITLE
copy zip to output folder

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,3 +69,8 @@ fi
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
+
+mkdir -p $OUTPUT/plugins
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
### Description
This PR fixed the issue that plugin zip is not copied to `artifacts` folder, the consequence was `opensearch-build` will not include `skills` when assembling opensearch distribution.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
