### PR TITLE
fix: some parsing exception from search index tool.

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -80,12 +80,11 @@ public class SearchIndexTool implements Tool {
 
     private SearchRequest getSearchRequest(String index, String query) throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        XContentParser queryParser = XContentType.JSON
-                .xContent()
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
+        XContentParser queryParser = XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, query);
         searchSourceBuilder.parseXContent(queryParser);
         return new SearchRequest().source(searchSourceBuilder).indices(index);
     }
+
     @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
         try {
@@ -102,8 +101,7 @@ public class SearchIndexTool implements Tool {
                     // try different json parsing method
                     query = jsonObject.get(QUERY_FIELD).getAsString();
                     searchRequest = getSearchRequest(index, query);
-                }
-                catch (Exception e2) {
+                } catch (Exception e2) {
                     // try wrapped query
                     query = "{\"query\": " + query + "}";
                     searchRequest = getSearchRequest(index, query);

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -88,16 +88,10 @@ public class SearchIndexTool implements Tool {
     @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
         try {
-            log.info("search index tool with parameters");
-            log.info(parameters.toString());
             String input = parameters.get(INPUT_FIELD);
             JsonObject jsonObject = StringUtils.gson.fromJson(input, JsonObject.class);
             String index = jsonObject.get(INDEX_FIELD).getAsString();
-            log.info("search index tool with index");
-            log.info(index);
             String query = jsonObject.get(QUERY_FIELD).toString();
-            log.info("search index tool with query");
-            log.info(query);
 
             SearchRequest searchRequest;
             try {

--- a/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchIndexTool.java
@@ -88,10 +88,16 @@ public class SearchIndexTool implements Tool {
     @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
         try {
+            log.info("search index tool with parameters");
+            log.info(parameters.toString());
             String input = parameters.get(INPUT_FIELD);
             JsonObject jsonObject = StringUtils.gson.fromJson(input, JsonObject.class);
             String index = jsonObject.get(INDEX_FIELD).getAsString();
+            log.info("search index tool with index");
+            log.info(index);
             String query = jsonObject.get(QUERY_FIELD).toString();
+            log.info("search index tool with query");
+            log.info(query);
 
             SearchRequest searchRequest;
             try {

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -17,14 +17,12 @@ import java.util.concurrent.CompletableFuture;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -156,9 +154,6 @@ public class SearchIndexToolTests {
         mockedSearchIndexTool.run(parameters, listener);
         Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
         Mockito.verify(client, Mockito.never()).search(any(), any());
-        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(ParsingException.class);
-        // since error message for ParsingException is different, we only need to expect ParsingException to be thrown
-        verify(listener).onFailure(argumentCaptor.capture());
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -84,7 +84,7 @@ public class SearchIndexToolTests {
 
     @Test
     public void testRunWithNormalIndex() {
-        String inputString = "{\"index\": \"test-index\", \"query\": {\"match_all\": {}}}";
+        String inputString = "{\"index\": \"test-index\", \"query\": {\"query\": {\"match_all\": {}}}}";
         Map<String, String> parameters = Map.of("input", inputString);
         mockedSearchIndexTool.run(parameters, null);
         Mockito.verify(client, times(1)).search(any(), any());
@@ -154,6 +154,26 @@ public class SearchIndexToolTests {
         mockedSearchIndexTool.run(parameters, listener);
         Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
         Mockito.verify(client, Mockito.never()).search(any(), any());
+    }
+
+    @Test
+    public void testRunWithEmptyQueryBody() {
+        // this empty query should be parsed with jsonObject.get(QUERY_FIELD).getAsString();
+        String inputString = "{\"index\": \"test-index\", \"query\": \"{}\"}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, times(1)).search(any(), any());
+        Mockito.verify(client, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testRunWithWrappedQuery() {
+        // this query should be wrapped liked "{\"query\": " + query + "}"
+        String inputString = "{\"index\": \".plugins-ml-model\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), any(), any());
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.transport.connector.MLConnectorSearchAction;
 import org.opensearch.ml.common.transport.model.MLModelSearchAction;
+import org.opensearch.ml.common.transport.model_group.MLModelGroupSearchAction;
 import org.opensearch.search.SearchModule;
 
 import lombok.SneakyThrows;
@@ -92,15 +93,6 @@ public class SearchIndexToolTests {
     }
 
     @Test
-    public void testRunWithModelGroupIndex() {
-        String inputString = "{\"index\": \".plugins-ml-model-group\", \"query\": {\"match_all\": {}}}";
-        Map<String, String> parameters = Map.of("input", inputString);
-        mockedSearchIndexTool.run(parameters, null);
-        Mockito.verify(client, never()).search(any(), any());
-        Mockito.verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), any(), any());
-    }
-
-    @Test
     public void testRunWithConnectorIndex() {
         String inputString = "{\"index\": \".plugins-ml-connector\", \"query\": {\"match_all\": {}}}";
         Map<String, String> parameters = Map.of("input", inputString);
@@ -116,6 +108,15 @@ public class SearchIndexToolTests {
         mockedSearchIndexTool.run(parameters, null);
         Mockito.verify(client, never()).search(any(), any());
         Mockito.verify(client, times(1)).execute(eq(MLModelSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
+    public void testRunWithModelGroupIndex() {
+        String inputString = "{\"index\": \".plugins-ml-model-group\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLModelGroupSearchAction.INSTANCE), any(), any());
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchIndexToolTests.java
@@ -92,6 +92,15 @@ public class SearchIndexToolTests {
     }
 
     @Test
+    public void testRunWithModelGroupIndex() {
+        String inputString = "{\"index\": \".plugins-ml-model-group\", \"query\": {\"match_all\": {}}}";
+        Map<String, String> parameters = Map.of("input", inputString);
+        mockedSearchIndexTool.run(parameters, null);
+        Mockito.verify(client, never()).search(any(), any());
+        Mockito.verify(client, times(1)).execute(eq(MLConnectorSearchAction.INSTANCE), any(), any());
+    }
+
+    @Test
     public void testRunWithConnectorIndex() {
         String inputString = "{\"index\": \".plugins-ml-connector\", \"query\": {\"match_all\": {}}}";
         Map<String, String> parameters = Map.of("input", inputString);


### PR DESCRIPTION
### Description
This PR can fix some parsing exceptions in search index tool.
 
### Issues Resolved
The LLM returns input parameters for search index tool in `action_input`. Before executing the DSL query to search the index, we need to parse the `query` field from `action_input`. Sometimes the DSL query given by LLM is problematic and thus lead to parsing exception. To support more user cases, we add two parsing methods in this PR to make it more likely to successfully execute search index tool.

This PR also adds one more unit test case for model group index.
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
