### PR TITLE
[Backport 2.x] Integrate search detectors tool with profile API (#88)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,8 @@ dependencies {
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${version}"
+
 
     // ZipArchive dependencies used for integration tests
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${version}"

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -179,7 +179,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
 
                 for (GetAnomalyDetectorResponse profileResponse : profileResponses) {
                     if (profileResponse != null && profileResponse.getDetector() != null) {
-                        String detectorId = profileResponse.getDetector().getId();
+                        String detectorId = profileResponse.getDetector().getDetectorId();
 
                         // We follow the existing logic as the frontend to determine overall detector state
                         // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/routes/utils/adHelpers.ts#L437

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -6,14 +6,23 @@
 package org.opensearch.agent.tools;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.client.AnomalyDetectionNodeClient;
+import org.opensearch.ad.model.ADTask;
+import org.opensearch.ad.transport.GetAnomalyDetectorRequest;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.agent.tools.utils.ToolConstants.DetectorStateString;
 import org.opensearch.client.Client;
+import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -123,24 +132,92 @@ public class SearchAnomalyDetectorsTool implements Tool {
 
         SearchRequest searchDetectorRequest = new SearchRequest().source(searchSourceBuilder);
 
-        if (running != null || disabled != null || failed != null) {
-            // TODO: add a listener to trigger when the first response is received, to trigger the profile API call
-            // to fetch the detector state, etc.
-            // Will need AD client to onboard the profile API first.
-        }
-
         ActionListener<SearchResponse> searchDetectorListener = ActionListener.<SearchResponse>wrap(response -> {
             StringBuilder sb = new StringBuilder();
-            SearchHit[] hits = response.getHits().getHits();
+            List<SearchHit> hits = Arrays.asList(response.getHits().getHits());
+            Map<String, SearchHit> hitsAsMap = hits.stream().collect(Collectors.toMap(SearchHit::getId, hit -> hit));
+
+            // If we need to filter by detector state, make subsequent profile API calls to each detector
+            if (running != null || disabled != null || failed != null) {
+                List<CompletableFuture<GetAnomalyDetectorResponse>> profileFutures = new ArrayList<>();
+                for (SearchHit hit : hits) {
+                    CompletableFuture<GetAnomalyDetectorResponse> profileFuture = new CompletableFuture<GetAnomalyDetectorResponse>()
+                        .orTimeout(30000, TimeUnit.MILLISECONDS);
+                    profileFutures.add(profileFuture);
+                    ActionListener<GetAnomalyDetectorResponse> profileListener = ActionListener
+                        .<GetAnomalyDetectorResponse>wrap(profileResponse -> {
+                            profileFuture.complete(profileResponse);
+                        }, e -> {
+                            log.error("Failed to get anomaly detector profile.", e);
+                            profileFuture.completeExceptionally(e);
+                            listener.onFailure(e);
+                        });
+
+                    GetAnomalyDetectorRequest profileRequest = new GetAnomalyDetectorRequest(
+                        hit.getId(),
+                        Versions.MATCH_ANY,
+                        true,
+                        true,
+                        "",
+                        "",
+                        false,
+                        null
+                    );
+                    adClient.getDetectorProfile(profileRequest, profileListener);
+                }
+
+                List<GetAnomalyDetectorResponse> profileResponses = new ArrayList<>();
+                try {
+                    CompletableFuture<List<GetAnomalyDetectorResponse>> listFuture = CompletableFuture
+                        .allOf(profileFutures.toArray(new CompletableFuture<?>[0]))
+                        .thenApply(v -> profileFutures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+                    profileResponses = listFuture.join();
+                } catch (Exception e) {
+                    log.error("Failed to get all anomaly detector profiles.", e);
+                    listener.onFailure(e);
+                }
+
+                for (GetAnomalyDetectorResponse profileResponse : profileResponses) {
+                    if (profileResponse != null && profileResponse.getDetector() != null) {
+                        String detectorId = profileResponse.getDetector().getId();
+
+                        // We follow the existing logic as the frontend to determine overall detector state
+                        // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/routes/utils/adHelpers.ts#L437
+                        String detectorState = DetectorStateString.Disabled.name();
+                        ADTask realtimeTask = profileResponse.getRealtimeAdTask();
+
+                        if (realtimeTask != null) {
+                            String taskState = realtimeTask.getState();
+                            if (taskState.equalsIgnoreCase("CREATED")) {
+                                detectorState = DetectorStateString.Initializing.name();
+                            } else if (taskState.equalsIgnoreCase("RUNNING")) {
+                                detectorState = DetectorStateString.Running.name();
+                            } else if (taskState.equalsIgnoreCase("INIT_FAILURE")
+                                || taskState.equalsIgnoreCase("UNEXPECTED_FAILURE")
+                                || taskState.equalsIgnoreCase("FAILED")) {
+                                detectorState = DetectorStateString.Failed.name();
+                            }
+                        }
+
+                        if ((Boolean.FALSE.equals(running) && detectorState.equals(DetectorStateString.Running.name()))
+                            || (Boolean.FALSE.equals(disabled) && detectorState.equals(DetectorStateString.Disabled.name()))
+                            || (Boolean.FALSE.equals(failed) && detectorState.equals(DetectorStateString.Failed.name()))) {
+                            hitsAsMap.remove(detectorId);
+                        }
+
+                    }
+                }
+            }
+
             sb.append("AnomalyDetectors=[");
-            for (SearchHit hit : hits) {
+            for (SearchHit hit : hitsAsMap.values()) {
                 sb.append("{");
                 sb.append("id=").append(hit.getId()).append(",");
                 sb.append("name=").append(hit.getSourceAsMap().get("name"));
                 sb.append("}");
             }
             sb.append("]");
-            sb.append("TotalAnomalyDetectors=").append(response.getHits().getTotalHits().value);
+            sb.append("TotalAnomalyDetectors=").append(hitsAsMap.size());
             listener.onResponse((T) sb.toString());
         }, e -> {
             log.error("Failed to search anomaly detectors.", e);

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools.utils;
+
+public class ToolConstants {
+    // Detector state is not cleanly defined on the backend plugin. So, we persist a standard
+    // set of states here for users to interface with when fetching and filtering detectors.
+    // This follows what frontend AD users are familiar with, as we use the same parsing logic
+    // in SearchAnomalyDetectorsTool.
+    public static enum DetectorStateString {
+        Running,
+        Disabled,
+        Failed,
+        Initializing
+    }
+}

--- a/src/test/java/org/opensearch/agent/TestHelpers.java
+++ b/src/test/java/org/opensearch/agent/TestHelpers.java
@@ -43,8 +43,8 @@ public class TestHelpers {
 
     public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorIds, String[] detectorStates) {
         AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
-        // For each subsequent call to getId(), return the next detectorId in the array
-        when(detector.getId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
+        // For each subsequent call to getDetectorId(), return the next detectorId in the array
+        when(detector.getDetectorId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
         ADTask realtimeAdTask = Mockito.mock(ADTask.class);
         // For each subsequent call to getState(), return the next detectorState in the array
         when(realtimeAdTask.getState()).thenReturn(detectorStates[0], Arrays.copyOfRange(detectorStates, 1, detectorStates.length));

--- a/src/test/java/org/opensearch/agent/TestHelpers.java
+++ b/src/test/java/org/opensearch/agent/TestHelpers.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.lucene.search.TotalHits;
+import org.mockito.Mockito;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.ad.model.ADTask;
+import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+
+public class TestHelpers {
+
+    public static SearchResponse generateSearchResponse(SearchHit[] hits) {
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+        return new SearchResponse(
+            new SearchResponseSections(new SearchHits(hits, totalHits, 0), new Aggregations(new ArrayList<>()), null, false, null, null, 0),
+            null,
+            0,
+            0,
+            0,
+            0,
+            null,
+            null
+        );
+    }
+
+    public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorIds, String[] detectorStates) {
+        AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
+        // For each subsequent call to getId(), return the next detectorId in the array
+        when(detector.getId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
+        ADTask realtimeAdTask = Mockito.mock(ADTask.class);
+        // For each subsequent call to getState(), return the next detectorState in the array
+        when(realtimeAdTask.getState()).thenReturn(detectorStates[0], Arrays.copyOfRange(detectorStates, 1, detectorStates.length));
+        GetAnomalyDetectorResponse getDetectorProfileResponse = Mockito.mock(GetAnomalyDetectorResponse.class);
+        when(getDetectorProfileResponse.getRealtimeAdTask()).thenReturn(realtimeAdTask);
+        when(getDetectorProfileResponse.getDetector()).thenReturn(detector);
+        return getDetectorProfileResponse;
+    }
+
+    public static SearchHit generateSearchDetectorHit(String detectorName, String detectorId) throws IOException {
+        XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
+        content.startObject();
+        content.field("name", detectorName);
+        content.endObject();
+        return new SearchHit(0, detectorId, null, null).sourceRef(BytesReference.bytes(content));
+    }
+}


### PR DESCRIPTION
### Description
Manual backport of #88 to 2.x. A few 2.x-specific changes had to be done.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
