### PR TITLE
ignore alias field

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -285,7 +285,9 @@ public class PPLTool implements Tool {
             if (v instanceof Map) {
                 Map<String, Object> vMap = (Map<String, Object>) v;
                 if (vMap.containsKey("type")) {
-                    fieldsToType.put(prefix + n, (String) vMap.get("type"));
+                    if (!((vMap.get("type")).equals("alias"))) {
+                        fieldsToType.put(prefix + n, (String) vMap.get("type"));
+                    }
                 } else if (vMap.containsKey("properties")) {
                     extractNamesTypes((Map<String, Object>) vMap.get("properties"), fieldsToType, prefix + n);
                 }

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -285,7 +285,7 @@ public class PPLTool implements Tool {
             if (v instanceof Map) {
                 Map<String, Object> vMap = (Map<String, Object>) v;
                 if (vMap.containsKey("type")) {
-                    if (!((vMap.get("type")).equals("alias"))) {
+                    if (!((vMap.getOrDefault("type", "")).equals("alias"))) {
                         fieldsToType.put(prefix + n, (String) vMap.get("type"));
                     }
                 } else if (vMap.containsKey("properties")) {


### PR DESCRIPTION
### Description
Ignore Alias field in the table information. Otherwise, it will confuse the LLM. The alias field cannot be executed by PPL.
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
