### PR TITLE
Set default index pattern for search AD results tool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.client.AnomalyDetectionNodeClient;
+import org.opensearch.agent.tools.utils.ToolConstants;
 import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -131,8 +132,9 @@ public class SearchAnomalyResultsTool implements Tool {
             .sort(sortString, sortOrder);
 
         // In the future we may support custom result indices. For now default to the default AD result system indices.
-        String resultIndices = ".opendistro-anomaly-results*";
-        SearchRequest searchAnomalyResultsRequest = new SearchRequest().source(searchSourceBuilder).indices(resultIndices);
+        SearchRequest searchAnomalyResultsRequest = new SearchRequest()
+            .source(searchSourceBuilder)
+            .indices(ToolConstants.AD_RESULTS_INDEX_PATTERN);
 
         ActionListener<SearchResponse> searchAnomalyResultsListener = ActionListener.<SearchResponse>wrap(response -> {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -130,7 +130,9 @@ public class SearchAnomalyResultsTool implements Tool {
             .from(startIndex)
             .sort(sortString, sortOrder);
 
-        SearchRequest searchAnomalyResultsRequest = new SearchRequest().source(searchSourceBuilder);
+        // In the future we may support custom result indices. For now default to the default AD result system indices.
+        String resultIndices = ".opendistro-anomaly-results*";
+        SearchRequest searchAnomalyResultsRequest = new SearchRequest().source(searchSourceBuilder).indices(resultIndices);
 
         ActionListener<SearchResponse> searchAnomalyResultsListener = ActionListener.<SearchResponse>wrap(response -> {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -16,4 +16,8 @@ public class ToolConstants {
         Failed,
         Initializing
     }
+
+    // System indices constants are not cleanly exposed from the AD plugin, so we persist our
+    // own constant here.
+    public static final String AD_RESULTS_INDEX_PATTERN = ".opendistro-anomaly-results*";
 }

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -32,6 +32,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.agent.tools.utils.ToolConstants;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.ClusterAdminClient;
 import org.opensearch.client.IndicesAdminClient;
@@ -196,7 +197,7 @@ public class SearchAnomalyResultsToolTests {
             String[] indices = generatedRequest.indices();
             assertNotNull(indices);
             assertEquals(1, indices.length);
-            assertEquals(".opendistro-anomaly-results*", indices[0]);
+            assertEquals(ToolConstants.AD_RESULTS_INDEX_PATTERN, indices[0]);
             return null;
         }).when(nodeClient).execute(any(ActionType.class), any(), any());
 

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.agent.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -28,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionType;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.client.AdminClient;
@@ -180,6 +182,25 @@ public class SearchAnomalyResultsToolTests {
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         assertEquals(expectedResponseStr, responseCaptor.getValue());
+    }
+
+    @Test
+    public void testDefaultIndexPatternIsSet() throws Exception {
+        Tool tool = SearchAnomalyResultsTool.Factory.getInstance().create(Collections.emptyMap());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> listener = Mockito.mock(ActionListener.class);
+
+        doAnswer((invocation) -> {
+            SearchRequest generatedRequest = invocation.getArgument(1);
+            String[] indices = generatedRequest.indices();
+            assertNotNull(indices);
+            assertEquals(1, indices.length);
+            assertEquals(".opendistro-anomaly-results*", indices[0]);
+            return null;
+        }).when(nodeClient).execute(any(ActionType.class), any(), any());
+
+        tool.run(emptyParams, listener);
     }
 
     @Test


### PR DESCRIPTION
### Description
There was a bug where the default `indices` field for the `SearchRequest` passed to the AD client was not set, causing an error in the respective AD transport action. This fixes that bug by adding a default index pattern. In the future we may support propagating custom result indices to the tool.

Added corresponding UT.

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
