### PR TITLE
Various AD tool improvements; add corresponding IT

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -140,12 +140,10 @@ public class SearchAnomalyResultsTool implements Tool {
             .source(searchSourceBuilder)
             .indices(ToolConstants.AD_RESULTS_INDEX_PATTERN);
 
-        log.info("SEARCH REQUEST");
-        log.info(searchAnomalyResultsRequest);
-
         ActionListener<SearchResponse> searchAnomalyResultsListener = ActionListener.<SearchResponse>wrap(response -> {
             processHits(response.getHits(), listener);
         }, e -> {
+            // System index isn't initialized by default, so ignore such errors
             if (e instanceof IndexNotFoundException) {
                 processHits(SearchHits.empty(), listener);
             } else {

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -93,7 +93,7 @@ public class SearchAnomalyResultsTool implements Tool {
             : null;
         final String sortOrderStr = parameters.getOrDefault("sortOrder", "asc");
         final SortOrder sortOrder = sortOrderStr.equalsIgnoreCase("asc") ? SortOrder.ASC : SortOrder.DESC;
-        final String sortString = parameters.getOrDefault("sortString", "name.keyword");
+        final String sortString = parameters.getOrDefault("sortString", "data_start_time");
         final int size = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
         final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
 
@@ -139,6 +139,9 @@ public class SearchAnomalyResultsTool implements Tool {
         SearchRequest searchAnomalyResultsRequest = new SearchRequest()
             .source(searchSourceBuilder)
             .indices(ToolConstants.AD_RESULTS_INDEX_PATTERN);
+
+        log.info("SEARCH REQUEST");
+        log.info(searchAnomalyResultsRequest);
 
         ActionListener<SearchResponse> searchAnomalyResultsListener = ActionListener.<SearchResponse>wrap(response -> {
             processHits(response.getHits(), listener);

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -20,4 +20,5 @@ public class ToolConstants {
     // System indices constants are not cleanly exposed from the AD plugin, so we persist our
     // own constant here.
     public static final String AD_RESULTS_INDEX_PATTERN = ".opendistro-anomaly-results*";
+    public static final String AD_DETECTORS_INDEX = ".opendistro-anomaly-detectors";
 }

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -5,9 +5,12 @@
 
 package org.opensearch.integTest;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.ContentType;
@@ -23,7 +26,11 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
@@ -144,6 +151,40 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
         Map<String, Object> responseInMap = parseResponseToMap(response);
         assertEquals("true", responseInMap.get("acknowledged").toString());
         assertEquals(indexName, responseInMap.get("index").toString());
+    }
+
+    // Similar to deleteExternalIndices, but including indices with "." prefix vs. excluding them
+    protected void deleteSystemIndices() throws IOException {
+        final Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json" + "&expand_wildcards=all"));
+        final MediaType xContentType = MediaType.fromMediaType(response.getEntity().getContentType());
+        try (
+            final XContentParser parser = xContentType
+                .xContent()
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    response.getEntity().getContent()
+                )
+        ) {
+            final XContentParser.Token token = parser.nextToken();
+            final List<Map<String, Object>> parserList;
+            if (token == XContentParser.Token.START_ARRAY) {
+                parserList = parser.listOrderedMap().stream().map(obj -> (Map<String, Object>) obj).collect(Collectors.toList());
+            } else {
+                parserList = Collections.singletonList(parser.mapOrdered());
+            }
+
+            final List<String> externalIndices = parserList
+                .stream()
+                .map(index -> (String) index.get("index"))
+                .filter(indexName -> indexName != null)
+                .filter(indexName -> indexName.startsWith("."))
+                .collect(Collectors.toList());
+
+            for (final String indexName : externalIndices) {
+                adminClient().performRequest(new Request("DELETE", "/" + indexName));
+            }
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -7,14 +7,19 @@ package org.opensearch.integTest;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
 
 import org.junit.After;
 import org.junit.Before;
+import org.opensearch.agent.tools.utils.ToolConstants;
 
 import lombok.SneakyThrows;
 
 public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     private String registerAgentRequestBody;
+    private static final String detectorId = "foo-id";
+    private static final String detectorName = "foo-name";
 
     @Before
     @SneakyThrows
@@ -31,6 +36,7 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
                             .toURI()
                     )
             );
+        createDetectorsSystemIndex(detectorId, detectorName);
     }
 
     @After
@@ -38,12 +44,52 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     public void tearDown() {
         super.tearDown();
         deleteExternalIndices();
+        deleteSystemIndices();
     }
 
+    @SneakyThrows
     public void testSearchAnomalyDetectorsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
         String agentId = createAgent(registerAgentRequestBody);
-        String agentInput = "{\n" + "  \"parameters\": {\n" + "    \"detectorId\": \"test-id\"\n" + "  }\n" + "}\n";
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
         String result = executeAgent(agentId, agentInput);
         assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals(
+            String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
+            result
+        );
+    }
+
+    @SneakyThrows
+    private void createDetectorsSystemIndex(String detectorId, String detectorName) {
+        createIndexWithConfiguration(
+            ToolConstants.AD_DETECTORS_INDEX,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"name\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(ToolConstants.AD_DETECTORS_INDEX, detectorId, List.of("name"), List.of(detectorName));
     }
 }

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+
+import lombok.SneakyThrows;
+
+public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+    }
+
+    public void testSearchAnomalyDetectorsToolInFlowAgent_withNoSystemIndex() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\n" + "  \"parameters\": {\n" + "    \"detectorId\": \"test-id\"\n" + "  }\n" + "}\n";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    }
+}

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
@@ -7,14 +7,20 @@ package org.opensearch.integTest;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
 
 import org.junit.After;
 import org.junit.Before;
+import org.opensearch.agent.tools.utils.ToolConstants;
 
 import lombok.SneakyThrows;
 
 public class SearchAnomalyResultsToolIT extends BaseAgentToolsIT {
     private String registerAgentRequestBody;
+    private static final String detectorId = "foo-id";
+    private static final String detectorName = "foo-name";
+    private static final String resultsSystemIndexName = ".opendistro-anomaly-results-1";
 
     @Before
     @SneakyThrows
@@ -31,6 +37,7 @@ public class SearchAnomalyResultsToolIT extends BaseAgentToolsIT {
                             .toURI()
                     )
             );
+        createAnomalyResultsSystemIndex(detectorId, detectorName);
     }
 
     @After
@@ -38,12 +45,52 @@ public class SearchAnomalyResultsToolIT extends BaseAgentToolsIT {
     public void tearDown() {
         super.tearDown();
         deleteExternalIndices();
+        deleteSystemIndices();
     }
 
+    @SneakyThrows
     public void testSearchAnomalyResultsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
         String agentId = createAgent(registerAgentRequestBody);
-        String agentInput = "{\n" + "  \"parameters\": {\n" + "    \"detectorId\": \"test-id\"\n" + "  }\n" + "}\n";
+        String agentInput = "{\"parameters\":{\"detectorId\": \"" + detectorId + "\"}}";
         String result = executeAgent(agentId, agentInput);
         assertEquals("AnomalyResults=[]TotalAnomalyResults=0", result);
+    }
+
+    // @SneakyThrows
+    // public void testSearchAnomalyResultsToolInFlowAgent_noMatching() {
+    //     String agentId = createAgent(registerAgentRequestBody);
+    //     String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+    //     String result = executeAgent(agentId, agentInput);
+    //     assertEquals("AnomalyResults=[]TotalAnomalyResults=0", result);
+    // }
+
+    // @SneakyThrows
+    // public void testSearchAnomalyResultsToolInFlowAgent_matching() {
+    //     String agentId = createAgent(registerAgentRequestBody);
+    //     String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+    //     String result = executeAgent(agentId, agentInput);
+    //     assertEquals(
+    //         String.format(Locale.ROOT, "AnomalyResults=[{id=%s,name=%s}]TotalAnomalyResults=%d", detectorId, detectorName, 1),
+    //         result
+    //     );
+    // }
+
+    @SneakyThrows
+    private void createAnomalyResultsSystemIndex(String detectorId, String detectorName) {
+        createIndexWithConfiguration(
+            resultsSystemIndexName,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"name\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(ToolConstants.AD_DETECTORS_INDEX, detectorId, List.of("name"), List.of(detectorName));
     }
 }

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+
+import lombok.SneakyThrows;
+
+public class SearchAnomalyResultsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+    }
+
+    public void testSearchAnomalyResultsToolInFlowAgent_withNoSystemIndex() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\n" + "  \"parameters\": {\n" + "    \"detectorId\": \"test-id\"\n" + "  }\n" + "}\n";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyResults=[]TotalAnomalyResults=0", result);
+    }
+}

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Anomaly_Results_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchAnomalyResultsTool",
+      "description": "Use this tool to search anomaly results."
+    }
+  ]
+}

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Detectors_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchAnomalyDetectorsTool",
+      "description": "Use this tool to search anomaly detectors."
+    }
+  ]
+}


### PR DESCRIPTION
### Description
This PR includes several AD tool improvements:
- handle edge case of missing AD system indices - this is expected when no detectors/results have been created, and we should gracefully handle instead of throwing errors. To process results in a consistent manner, refactored the stringbuilding logic into helper methods in both tools
- Explicitly set the AD config index in the search detectors tool to mimic REST API logic
- Fix bug of invalid sort string in search AD results tool
- Add corresponding IT for both AD tools

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
