### PR TITLE
[Backport 2.x]  Various AD tool improvements; add corresponding IT (#117)

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -16,6 +16,7 @@ import org.opensearch.ad.client.AnomalyDetectionNodeClient;
 import org.opensearch.agent.tools.utils.ToolConstants;
 import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -26,12 +27,15 @@ import org.opensearch.ml.common.spi.tools.Parser;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 @ToolAnnotation(SearchAnomalyResultsTool.TYPE)
 public class SearchAnomalyResultsTool implements Tool {
     public static final String TYPE = "SearchAnomalyResultsTool";
@@ -89,7 +93,7 @@ public class SearchAnomalyResultsTool implements Tool {
             : null;
         final String sortOrderStr = parameters.getOrDefault("sortOrder", "asc");
         final SortOrder sortOrder = sortOrderStr.equalsIgnoreCase("asc") ? SortOrder.ASC : SortOrder.DESC;
-        final String sortString = parameters.getOrDefault("sortString", "name.keyword");
+        final String sortString = parameters.getOrDefault("sortString", "data_start_time");
         final int size = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
         final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
 
@@ -137,20 +141,17 @@ public class SearchAnomalyResultsTool implements Tool {
             .indices(ToolConstants.AD_RESULTS_INDEX_PATTERN);
 
         ActionListener<SearchResponse> searchAnomalyResultsListener = ActionListener.<SearchResponse>wrap(response -> {
-            StringBuilder sb = new StringBuilder();
-            SearchHit[] hits = response.getHits().getHits();
-            sb.append("AnomalyResults=[");
-            for (SearchHit hit : hits) {
-                sb.append("{");
-                sb.append("detectorId=").append(hit.getSourceAsMap().get("detector_id")).append(",");
-                sb.append("grade=").append(hit.getSourceAsMap().get("anomaly_grade")).append(",");
-                sb.append("confidence=").append(hit.getSourceAsMap().get("confidence"));
-                sb.append("}");
+            processHits(response.getHits(), listener);
+        }, e -> {
+            // System index isn't initialized by default, so ignore such errors
+            if (e instanceof IndexNotFoundException) {
+                processHits(SearchHits.empty(), listener);
+            } else {
+                log.error("Failed to search anomaly results.", e);
+                listener.onFailure(e);
+
             }
-            sb.append("]");
-            sb.append("TotalAnomalyResults=").append(response.getHits().getTotalHits().value);
-            listener.onResponse((T) sb.toString());
-        }, e -> { listener.onFailure(e); });
+        });
 
         adClient.searchAnomalyResults(searchAnomalyResultsRequest, searchAnomalyResultsListener);
     }
@@ -163,6 +164,23 @@ public class SearchAnomalyResultsTool implements Tool {
     @Override
     public String getType() {
         return TYPE;
+    }
+
+    private <T> void processHits(SearchHits searchHits, ActionListener<T> listener) {
+        SearchHit[] hits = searchHits.getHits();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("AnomalyResults=[");
+        for (SearchHit hit : hits) {
+            sb.append("{");
+            sb.append("detectorId=").append(hit.getSourceAsMap().get("detector_id")).append(",");
+            sb.append("grade=").append(hit.getSourceAsMap().get("anomaly_grade")).append(",");
+            sb.append("confidence=").append(hit.getSourceAsMap().get("confidence"));
+            sb.append("}");
+        }
+        sb.append("]");
+        sb.append("TotalAnomalyResults=").append(searchHits.getTotalHits().value);
+        listener.onResponse((T) sb.toString());
     }
 
     /**

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -20,4 +20,5 @@ public class ToolConstants {
     // System indices constants are not cleanly exposed from the AD plugin, so we persist our
     // own constant here.
     public static final String AD_RESULTS_INDEX_PATTERN = ".opendistro-anomaly-results*";
+    public static final String AD_DETECTORS_INDEX = ".opendistro-anomaly-detectors";
 }

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -25,9 +25,9 @@ import org.opensearch.client.*;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.DeprecationHandler;
-import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -156,10 +156,8 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
     // Similar to deleteExternalIndices, but including indices with "." prefix vs. excluding them
     protected void deleteSystemIndices() throws IOException {
         final Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json" + "&expand_wildcards=all"));
-        final MediaType xContentType = MediaType.fromMediaType(response.getEntity().getContentType());
         try (
-            final XContentParser parser = xContentType
-                .xContent()
+            final XContentParser parser = JsonXContent.jsonXContent
                 .createParser(
                     NamedXContentRegistry.EMPTY,
                     DeprecationHandler.THROW_UNSUPPORTED_OPERATION,

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.agent.tools.utils.ToolConstants;
+
+import lombok.SneakyThrows;
+
+public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+    private static final String detectorId = "foo-id";
+    private static final String detectorName = "foo-name";
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+        createDetectorsSystemIndex(detectorId, detectorName);
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+        deleteSystemIndices();
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyDetectorsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals(
+            String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
+            result
+        );
+    }
+
+    @SneakyThrows
+    private void createDetectorsSystemIndex(String detectorId, String detectorName) {
+        createIndexWithConfiguration(
+            ToolConstants.AD_DETECTORS_INDEX,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"name\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(ToolConstants.AD_DETECTORS_INDEX, detectorId, List.of("name"), List.of(detectorName));
+    }
+}

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyResultsToolIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+
+import lombok.SneakyThrows;
+
+public class SearchAnomalyResultsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+    private static final String detectorId = "foo-id";
+    private static final double anomalyGrade = 0.5;
+    private static final double confidence = 0.6;
+    private static final String resultsSystemIndexName = ".opendistro-anomaly-results-1";
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+        createAnomalyResultsSystemIndex(detectorId, anomalyGrade, confidence);
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+        deleteSystemIndices();
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyResultsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorId\": \"" + detectorId + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyResults=[]TotalAnomalyResults=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyResultsToolInFlowAgent_noMatching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorId\": \"" + detectorId + "foo" + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("AnomalyResults=[]TotalAnomalyResults=0", result);
+    }
+
+    @SneakyThrows
+    public void testSearchAnomalyResultsToolInFlowAgent_matching() {
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"detectorId\": \"" + detectorId + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals(
+            String
+                .format(
+                    Locale.ROOT,
+                    "AnomalyResults=[{detectorId=%s,grade=%2.1f,confidence=%2.1f}]TotalAnomalyResults=%d",
+                    detectorId,
+                    anomalyGrade,
+                    confidence,
+                    1
+                ),
+            result
+        );
+    }
+
+    @SneakyThrows
+    private void createAnomalyResultsSystemIndex(String detectorId, double anomalyGrade, double confidence) {
+        createIndexWithConfiguration(
+            resultsSystemIndexName,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"detector_id\": {\"type\": \"keyword\"},"
+                + "      \"anomaly_grade\": {\"type\": \"double\"},"
+                + "      \"confidence\": {\"type\": \"double\"},"
+                + "      \"data_start_time\": {\"type\": \"date\", \"format\": \"strict_date_time||epoch_millis\"}"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(
+            resultsSystemIndexName,
+            "foo-id",
+            List.of("detector_id", "anomaly_grade", "confidence"),
+            List.of(detectorId, anomalyGrade, confidence)
+        );
+    }
+}

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_anomaly_results_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Anomaly_Results_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchAnomalyResultsTool",
+      "description": "Use this tool to search anomaly results."
+    }
+  ]
+}

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_detectors_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Detectors_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchAnomalyDetectorsTool",
+      "description": "Use this tool to search anomaly detectors."
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Manual backport of #117 

Needs manual updates to `deleteSystemIndices()` to handle compile errors unique to 2.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
