### PR TITLE
Add alerting tools IT; fix missing system index bug of SearchMonitorsTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ apply plugin: 'opensearch.pluginzip'
 def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
 def jsJarDirectory = "$buildDir/dependencies/opensearch-job-scheduler"
 def adJarDirectory = "$buildDir/dependencies/opensearch-time-series-analytics"
+// def alertingJarDirectory = "$buildDir/dependencies/alerting"
 
 configurations {
     zipArchive
@@ -101,6 +102,11 @@ task addJarsToClasspath(type: Copy) {
         include "opensearch-time-series-analytics-${version}.jar"
     }
     into("$buildDir/classes")
+
+    //     from(fileTree(dir: alertingJarDirectory)) {
+    //     include "alerting-${version}.jar"
+    // }
+    // into("$buildDir/classes")
 }
 
 dependencies {
@@ -116,10 +122,12 @@ dependencies {
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
     implementation fileTree(dir: jsJarDirectory, include: ["opensearch-job-scheduler-${version}.jar"])
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
+    // implementation fileTree(dir: alertingJarDirectory, include: ["alerting-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${version}"
+    // compileOnly "org.opensearch.plugin:alerting:${version}"
 
 
     // ZipArchive dependencies used for integration tests
@@ -129,6 +137,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'neural-search', version: "${version}"
+    zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${version}"
 
     // Test dependencies
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -164,9 +173,16 @@ task extractAdJar(type: Copy) {
     into adJarDirectory
 }
 
+// task extractAlertingJar(type: Copy) {
+//     mustRunAfter()
+//     from(zipTree(configurations.zipArchive.find { it.name.startsWith("alerting")}))
+//     into alertingJarDirectory
+// }
+
 tasks.addJarsToClasspath.dependsOn(extractSqlJar)
 tasks.addJarsToClasspath.dependsOn(extractJsJar)
 tasks.addJarsToClasspath.dependsOn(extractAdJar)
+// tasks.addJarsToClasspath.dependsOn(extractAlertingJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
@@ -212,6 +228,7 @@ compileJava {
     dependsOn extractSqlJar
     dependsOn extractJsJar
     dependsOn extractAdJar
+    // dependsOn extractAlertingJar
     dependsOn delombok
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'neural-search', version: "${version}"
+    zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${version}"
 
     // Test dependencies
     testImplementation "org.opensearch.test:framework:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ apply plugin: 'opensearch.pluginzip'
 def sqlJarDirectory = "$buildDir/dependencies/opensearch-sql-plugin"
 def jsJarDirectory = "$buildDir/dependencies/opensearch-job-scheduler"
 def adJarDirectory = "$buildDir/dependencies/opensearch-time-series-analytics"
-// def alertingJarDirectory = "$buildDir/dependencies/alerting"
 
 configurations {
     zipArchive
@@ -102,11 +101,6 @@ task addJarsToClasspath(type: Copy) {
         include "opensearch-time-series-analytics-${version}.jar"
     }
     into("$buildDir/classes")
-
-    //     from(fileTree(dir: alertingJarDirectory)) {
-    //     include "alerting-${version}.jar"
-    // }
-    // into("$buildDir/classes")
 }
 
 dependencies {
@@ -122,12 +116,10 @@ dependencies {
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${version}"
     implementation fileTree(dir: jsJarDirectory, include: ["opensearch-job-scheduler-${version}.jar"])
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${version}.jar"])
-    // implementation fileTree(dir: alertingJarDirectory, include: ["alerting-${version}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${version}.jar", "ppl-${version}.jar", "protocol-${version}.jar"])
     compileOnly "org.opensearch:common-utils:${version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${version}"
-    // compileOnly "org.opensearch.plugin:alerting:${version}"
 
 
     // ZipArchive dependencies used for integration tests
@@ -137,7 +129,6 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${version}"
     zipArchive group: 'org.opensearch.plugin', name:'neural-search', version: "${version}"
-    zipArchive group: 'org.opensearch.plugin', name:'alerting', version: "${version}"
 
     // Test dependencies
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -173,16 +164,9 @@ task extractAdJar(type: Copy) {
     into adJarDirectory
 }
 
-// task extractAlertingJar(type: Copy) {
-//     mustRunAfter()
-//     from(zipTree(configurations.zipArchive.find { it.name.startsWith("alerting")}))
-//     into alertingJarDirectory
-// }
-
 tasks.addJarsToClasspath.dependsOn(extractSqlJar)
 tasks.addJarsToClasspath.dependsOn(extractJsJar)
 tasks.addJarsToClasspath.dependsOn(extractAdJar)
-// tasks.addJarsToClasspath.dependsOn(extractAlertingJar)
 project.tasks.delombok.dependsOn(addJarsToClasspath)
 tasks.publishNebulaPublicationToMavenLocal.dependsOn ':generatePomFileForPluginZipPublication'
 tasks.validateNebulaPom.dependsOn ':generatePomFileForPluginZipPublication'
@@ -228,7 +212,6 @@ compileJava {
     dependsOn extractSqlJar
     dependsOn extractJsJar
     dependsOn extractAdJar
-    // dependsOn extractAlertingJar
     dependsOn delombok
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
 }

--- a/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
@@ -6,8 +6,11 @@
 package org.opensearch.agent.tools;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.search.join.ScoreMode;
@@ -105,22 +108,17 @@ public class SearchMonitorsTool implements Tool {
         if (monitorId != null) {
             GetMonitorRequest getMonitorRequest = new GetMonitorRequest(monitorId, 1L, RestRequest.Method.GET, null);
             ActionListener<GetMonitorResponse> getMonitorListener = ActionListener.<GetMonitorResponse>wrap(response -> {
-                StringBuilder sb = new StringBuilder();
                 Monitor monitor = response.getMonitor();
-                if (monitor != null) {
-                    sb.append("Monitors=[");
-                    sb.append("{");
-                    sb.append("id=").append(monitor.getId()).append(",");
-                    sb.append("name=").append(monitor.getName());
-                    sb.append("}]");
-                    sb.append("TotalMonitors=1");
-                } else {
-                    sb.append("Monitors=[]TotalMonitors=0");
-                }
-                listener.onResponse((T) sb.toString());
+                processGetMonitorHit(monitor, listener);
             }, e -> {
-                log.error("Failed to search monitors.", e);
-                listener.onFailure(e);
+                // System index isn't initialized by default, so ignore such errors. Alerting plugin does not return the
+                // standard IndexNotFoundException so we parse the message instead
+                if (e.getMessage().contains("Configured indices are not found")) {
+                    processGetMonitorHit(null, listener);
+                } else {
+                    log.error("Failed to get monitor.", e);
+                    listener.onFailure(e);
+                }
             });
             AlertingPluginInterface.INSTANCE.getMonitor((NodeClient) client, getMonitorRequest, getMonitorListener);
         } else {
@@ -172,21 +170,19 @@ public class SearchMonitorsTool implements Tool {
             SearchMonitorRequest searchMonitorRequest = new SearchMonitorRequest(searchRequest);
 
             ActionListener<SearchResponse> searchMonitorListener = ActionListener.<SearchResponse>wrap(response -> {
-                StringBuilder sb = new StringBuilder();
-                SearchHit[] hits = response.getHits().getHits();
-                sb.append("Monitors=[");
-                for (SearchHit hit : hits) {
-                    sb.append("{");
-                    sb.append("id=").append(hit.getId()).append(",");
-                    sb.append("name=").append(hit.getSourceAsMap().get("name"));
-                    sb.append("}");
-                }
-                sb.append("]");
-                sb.append("TotalMonitors=").append(response.getHits().getTotalHits().value);
-                listener.onResponse((T) sb.toString());
+                List<SearchHit> hits = Arrays.asList(response.getHits().getHits());
+                Map<String, SearchHit> hitsAsMap = hits.stream().collect(Collectors.toMap(SearchHit::getId, hit -> hit));
+                processHits(hitsAsMap, listener);
+
             }, e -> {
-                log.error("Failed to search monitors.", e);
-                listener.onFailure(e);
+                // System index isn't initialized by default, so ignore such errors. Alerting plugin does not return the
+                // standard IndexNotFoundException so we parse the message instead
+                if (e.getMessage().contains("Configured indices are not found")) {
+                    processHits(Collections.emptyMap(), listener);
+                } else {
+                    log.error("Failed to search monitors.", e);
+                    listener.onFailure(e);
+                }
             });
             AlertingPluginInterface.INSTANCE.searchMonitors((NodeClient) client, searchMonitorRequest, searchMonitorListener);
         }
@@ -200,6 +196,35 @@ public class SearchMonitorsTool implements Tool {
     @Override
     public String getType() {
         return TYPE;
+    }
+
+    private <T> void processHits(Map<String, SearchHit> hitsAsMap, ActionListener<T> listener) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Monitors=[");
+        for (SearchHit hit : hitsAsMap.values()) {
+            sb.append("{");
+            sb.append("id=").append(hit.getId()).append(",");
+            sb.append("name=").append(hit.getSourceAsMap().get("name"));
+            sb.append("}");
+        }
+        sb.append("]");
+        sb.append("TotalMonitors=").append(hitsAsMap.size());
+        listener.onResponse((T) sb.toString());
+    }
+
+    private <T> void processGetMonitorHit(Monitor monitor, ActionListener<T> listener) {
+        StringBuilder sb = new StringBuilder();
+        if (monitor != null) {
+            sb.append("Monitors=[");
+            sb.append("{");
+            sb.append("id=").append(monitor.getId()).append(",");
+            sb.append("name=").append(monitor.getName());
+            sb.append("}]");
+            sb.append("TotalMonitors=1");
+        } else {
+            sb.append("Monitors=[]TotalMonitors=0");
+        }
+        listener.onResponse((T) sb.toString());
     }
 
     /**

--- a/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
@@ -20,6 +20,7 @@ import org.opensearch.commons.alerting.action.GetMonitorRequest;
 import org.opensearch.commons.alerting.action.GetMonitorResponse;
 import org.opensearch.commons.alerting.action.SearchMonitorRequest;
 import org.opensearch.commons.alerting.model.Monitor;
+import org.opensearch.commons.alerting.model.ScheduledJob;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
@@ -167,7 +168,8 @@ public class SearchMonitorsTool implements Tool {
                 .from(startIndex)
                 .sort(sortString, sortOrder);
 
-            SearchMonitorRequest searchMonitorRequest = new SearchMonitorRequest(new SearchRequest().source(searchSourceBuilder));
+            SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(ScheduledJob.SCHEDULED_JOBS_INDEX);
+            SearchMonitorRequest searchMonitorRequest = new SearchMonitorRequest(searchRequest);
 
             ActionListener<SearchResponse> searchMonitorListener = ActionListener.<SearchResponse>wrap(response -> {
                 StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/ToolConstants.java
@@ -17,8 +17,10 @@ public class ToolConstants {
         Initializing
     }
 
-    // System indices constants are not cleanly exposed from the AD plugin, so we persist our
-    // own constant here.
+    // System indices constants are not cleanly exposed from the AD & Alerting plugins, so we persist our
+    // own constants here.
     public static final String AD_RESULTS_INDEX_PATTERN = ".opendistro-anomaly-results*";
     public static final String AD_DETECTORS_INDEX = ".opendistro-anomaly-detectors";
+
+    public static final String ALERTING_CONFIG_INDEX = ".opendistro-alerting-config";
 }

--- a/src/test/java/org/opensearch/integTest/SearchAlertsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAlertsToolIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.integTest;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.agent.tools.utils.ToolConstants;
+
+import lombok.SneakyThrows;
+
+public class SearchAlertsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+    private static final String monitorId = "foo-id";
+    private static final String monitorName = "foo-name";
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_alerts_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+        createAlertsSystemIndex(monitorId, monitorName);
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+        deleteSystemIndices();
+    }
+
+    @SneakyThrows
+    public void testSearchAlertsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"monitorId\": \"" + monitorId + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("Alerts=[]TotalAlerts=0", result);
+    }
+
+    @SneakyThrows
+    private void createAlertsSystemIndex(String monitorId, String monitorName) {
+        createIndexWithConfiguration(
+            ToolConstants.ALERTING_CONFIG_INDEX,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"name\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
+    }
+}

--- a/src/test/java/org/opensearch/integTest/SearchAlertsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAlertsToolIT.java
@@ -7,11 +7,9 @@ package org.opensearch.integTest;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.agent.tools.utils.ToolConstants;
 
 import lombok.SneakyThrows;
 
@@ -35,7 +33,6 @@ public class SearchAlertsToolIT extends BaseAgentToolsIT {
                             .toURI()
                     )
             );
-        createAlertsSystemIndex(monitorId, monitorName);
     }
 
     @After
@@ -55,21 +52,6 @@ public class SearchAlertsToolIT extends BaseAgentToolsIT {
         assertEquals("Alerts=[]TotalAlerts=0", result);
     }
 
-    @SneakyThrows
-    private void createAlertsSystemIndex(String monitorId, String monitorName) {
-        createIndexWithConfiguration(
-            ToolConstants.ALERTING_CONFIG_INDEX,
-            "{\n"
-                + "  \"mappings\": {\n"
-                + "    \"properties\": {\n"
-                + "      \"name\": {\n"
-                + "        \"type\": \"text\",\n"
-                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
-                + "      }\n"
-                + "    }\n"
-                + "  }\n"
-                + "}"
-        );
-        addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
-    }
+    // TODO: Add IT to test against sample alerts data
+    // https://github.com/opensearch-project/skills/issues/136
 }

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -55,25 +55,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
         assertEquals("Monitors=[]TotalMonitors=0", result);
     }
 
-    // @SneakyThrows
-    // public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
-    // String agentId = createAgent(registerAgentRequestBody);
-    // String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
-    // String result = executeAgent(agentId, agentInput);
-    // assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
-    // }
-
-    // @SneakyThrows
-    // public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
-    // String agentId = createAgent(registerAgentRequestBody);
-    // String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
-    // String result = executeAgent(agentId, agentInput);
-    // assertEquals(
-    // String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
-    // result
-    // );
-    // }
-
     @SneakyThrows
     private void createMonitorsSystemIndex(String monitorId, String monitorName) {
         createIndexWithConfiguration(

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -3,94 +3,92 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- package org.opensearch.integTest;
+package org.opensearch.integTest;
 
- import java.nio.file.Files;
- import java.nio.file.Path;
- import java.util.List;
- import java.util.Locale;
- 
- import org.junit.After;
- import org.junit.Before;
- import org.opensearch.agent.tools.utils.ToolConstants;
- 
- import lombok.SneakyThrows;
- 
- public class SearchMonitorsToolIT extends BaseAgentToolsIT {
-     private String registerAgentRequestBody;
-     private static final String monitorId = "foo-id";
-     private static final String monitorName = "foo-name";
- 
-     @Before
-     @SneakyThrows
-     public void setUp() {
-         super.setUp();
-         registerAgentRequestBody = Files
-             .readString(
-                 Path
-                     .of(
-                         this
-                             .getClass()
-                             .getClassLoader()
-                             .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_monitors_tool_request_body.json")
-                             .toURI()
-                     )
-             );
-         createMonitorsSystemIndex(monitorId, monitorName);
-     }
- 
-     @After
-     @SneakyThrows
-     public void tearDown() {
-         super.tearDown();
-         deleteExternalIndices();
-         deleteSystemIndices();
-     }
- 
-     @SneakyThrows
-     public void testSearchMonitorsToolInFlowAgent_withNoSystemIndex() {
-         deleteSystemIndices();
-         String agentId = createAgent(registerAgentRequestBody);
-         String agentInput = "{\"parameters\":{\"monitorName\": \"" + monitorName + "\"}}";
-         String result = executeAgent(agentId, agentInput);
-         assertEquals("Monitors=[]TotalMonitors=0", result);
-     }
- 
-    //  @SneakyThrows
-    //  public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
-    //      String agentId = createAgent(registerAgentRequestBody);
-    //      String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
-    //      String result = executeAgent(agentId, agentInput);
-    //      assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
-    //  }
- 
-    //  @SneakyThrows
-    //  public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
-    //      String agentId = createAgent(registerAgentRequestBody);
-    //      String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
-    //      String result = executeAgent(agentId, agentInput);
-    //      assertEquals(
-    //          String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
-    //          result
-    //      );
-    //  }
- 
-     @SneakyThrows
-     private void createMonitorsSystemIndex(String monitorId, String monitorName) {
-         createIndexWithConfiguration(
-             ToolConstants.ALERTING_CONFIG_INDEX,
-             "{\n"
-                 + "  \"mappings\": {\n"
-                 + "    \"properties\": {\n"
-                 + "      \"name\": {\n"
-                 + "        \"type\": \"text\",\n"
-                 + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
-                 + "      }\n"
-                 + "    }\n"
-                 + "  }\n"
-                 + "}"
-         );
-         addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
-     }
- }
- 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.agent.tools.utils.ToolConstants;
+
+import lombok.SneakyThrows;
+
+public class SearchMonitorsToolIT extends BaseAgentToolsIT {
+    private String registerAgentRequestBody;
+    private static final String monitorId = "foo-id";
+    private static final String monitorName = "foo-name";
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        registerAgentRequestBody = Files
+            .readString(
+                Path
+                    .of(
+                        this
+                            .getClass()
+                            .getClassLoader()
+                            .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_monitors_tool_request_body.json")
+                            .toURI()
+                    )
+            );
+        createMonitorsSystemIndex(monitorId, monitorName);
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteExternalIndices();
+        deleteSystemIndices();
+    }
+
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_withNoSystemIndex() {
+        deleteSystemIndices();
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"monitorName\": \"" + monitorName + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertEquals("Monitors=[]TotalMonitors=0", result);
+    }
+
+    // @SneakyThrows
+    // public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
+    // String agentId = createAgent(registerAgentRequestBody);
+    // String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+    // String result = executeAgent(agentId, agentInput);
+    // assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    // }
+
+    // @SneakyThrows
+    // public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
+    // String agentId = createAgent(registerAgentRequestBody);
+    // String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+    // String result = executeAgent(agentId, agentInput);
+    // assertEquals(
+    // String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
+    // result
+    // );
+    // }
+
+    @SneakyThrows
+    private void createMonitorsSystemIndex(String monitorId, String monitorName) {
+        createIndexWithConfiguration(
+            ToolConstants.ALERTING_CONFIG_INDEX,
+            "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"name\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+        addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
+    }
+}

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -9,11 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.agent.tools.utils.ToolConstants;
 
 import lombok.SneakyThrows;
 

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.integTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -54,6 +56,8 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
         String result = executeAgent(agentId, agentInput);
         assertEquals("Monitors=[]TotalMonitors=0", result);
     }
+
+    // TODO: Add IT to test against sample monitor data
 
     @SneakyThrows
     private void createMonitorsSystemIndex(String monitorId, String monitorName) {

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ package org.opensearch.integTest;
+
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+ import java.util.List;
+ import java.util.Locale;
+ 
+ import org.junit.After;
+ import org.junit.Before;
+ import org.opensearch.agent.tools.utils.ToolConstants;
+ 
+ import lombok.SneakyThrows;
+ 
+ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
+     private String registerAgentRequestBody;
+     private static final String monitorId = "foo-id";
+     private static final String monitorName = "foo-name";
+ 
+     @Before
+     @SneakyThrows
+     public void setUp() {
+         super.setUp();
+         registerAgentRequestBody = Files
+             .readString(
+                 Path
+                     .of(
+                         this
+                             .getClass()
+                             .getClassLoader()
+                             .getResource("org/opensearch/agent/tools/register_flow_agent_of_search_monitors_tool_request_body.json")
+                             .toURI()
+                     )
+             );
+         createMonitorsSystemIndex(monitorId, monitorName);
+     }
+ 
+     @After
+     @SneakyThrows
+     public void tearDown() {
+         super.tearDown();
+         deleteExternalIndices();
+         deleteSystemIndices();
+     }
+ 
+     @SneakyThrows
+     public void testSearchMonitorsToolInFlowAgent_withNoSystemIndex() {
+         deleteSystemIndices();
+         String agentId = createAgent(registerAgentRequestBody);
+         String agentInput = "{\"parameters\":{\"monitorName\": \"" + monitorName + "\"}}";
+         String result = executeAgent(agentId, agentInput);
+         assertEquals("Monitors=[]TotalMonitors=0", result);
+     }
+ 
+    //  @SneakyThrows
+    //  public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
+    //      String agentId = createAgent(registerAgentRequestBody);
+    //      String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+    //      String result = executeAgent(agentId, agentInput);
+    //      assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+    //  }
+ 
+    //  @SneakyThrows
+    //  public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
+    //      String agentId = createAgent(registerAgentRequestBody);
+    //      String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+    //      String result = executeAgent(agentId, agentInput);
+    //      assertEquals(
+    //          String.format(Locale.ROOT, "AnomalyDetectors=[{id=%s,name=%s}]TotalAnomalyDetectors=%d", detectorId, detectorName, 1),
+    //          result
+    //      );
+    //  }
+ 
+     @SneakyThrows
+     private void createMonitorsSystemIndex(String monitorId, String monitorName) {
+         createIndexWithConfiguration(
+             ToolConstants.ALERTING_CONFIG_INDEX,
+             "{\n"
+                 + "  \"mappings\": {\n"
+                 + "    \"properties\": {\n"
+                 + "      \"name\": {\n"
+                 + "        \"type\": \"text\",\n"
+                 + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
+                 + "      }\n"
+                 + "    }\n"
+                 + "  }\n"
+                 + "}"
+         );
+         addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
+     }
+ }
+ 

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -37,7 +37,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
                             .toURI()
                     )
             );
-        createMonitorsSystemIndex(monitorId, monitorName);
     }
 
     @After

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -58,22 +58,4 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
     }
 
     // TODO: Add IT to test against sample monitor data
-
-    @SneakyThrows
-    private void createMonitorsSystemIndex(String monitorId, String monitorName) {
-        createIndexWithConfiguration(
-            ToolConstants.ALERTING_CONFIG_INDEX,
-            "{\n"
-                + "  \"mappings\": {\n"
-                + "    \"properties\": {\n"
-                + "      \"name\": {\n"
-                + "        \"type\": \"text\",\n"
-                + "             \"fields\": { \"keyword\": { \"type\": \"keyword\", \"ignore_above\": 256 }}"
-                + "      }\n"
-                + "    }\n"
-                + "  }\n"
-                + "}"
-        );
-        addDocToIndex(ToolConstants.ALERTING_CONFIG_INDEX, monitorId, List.of("name"), List.of(monitorName));
-    }
 }

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_alerts_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_alerts_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Alerts_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchAlertsTool",
+      "description": "Use this tool to search alerts."
+    }
+  ]
+}

--- a/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_monitors_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/register_flow_agent_of_search_monitors_tool_request_body.json
@@ -1,0 +1,10 @@
+{
+  "name": "Test_Search_Monitors_Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchMonitorsTool",
+      "description": "Use this tool to search alerting monitors."
+    }
+  ]
+}


### PR DESCRIPTION
### Description
This PR adds improvements to the existing SearchAlertsTool and SearchMonitors tools:
- adds basic integ tests (more to be added tracked in followup issue #136)
- handles edge cases of missing system indices for SearchMonitorsTool
- cleans up processing logic of responses into helper fns for SearchMonitorsTool
 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
