### PR TITLE
Enhance RagTool to choose neural sparse query type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         java: 
           - 11
           - 17
-          - 21
+          - 21.0.1
     name: Build and Test skills plugin on Linux
     runs-on: ubuntu-latest
     container:
@@ -100,7 +100,7 @@ jobs:
         java: 
           - 11
           - 17
-          - 21
+          - 21.0.1
     name: Build and Test skills plugin on Windows
     needs: Get-CI-Image-Tag
     runs-on: windows-latest

--- a/src/main/java/org/opensearch/agent/tools/RAGTool.java
+++ b/src/main/java/org/opensearch/agent/tools/RAGTool.java
@@ -6,7 +6,7 @@
 package org.opensearch.agent.tools;
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeJson;
-import static org.opensearch.agent.tools.VectorDBTool.DEFAULT_K;
+import static org.opensearch.agent.tools.AbstractRetrieverTool.*;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 import static org.opensearch.ml.common.utils.StringUtils.toJson;
 
@@ -21,10 +21,10 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
-import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.spi.tools.Parser;
+import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
@@ -44,29 +44,28 @@ import lombok.extern.log4j.Log4j2;
 @Setter
 @Getter
 @ToolAnnotation(RAGTool.TYPE)
-public class RAGTool extends AbstractRetrieverTool {
+public class RAGTool implements Tool {
     public static final String TYPE = "RAGTool";
     public static String DEFAULT_DESCRIPTION =
         "Use this tool to retrieve helpful information to optimize the output of the large language model to answer questions.";
     public static final String INFERENCE_MODEL_ID_FIELD = "inference_model_id";
     public static final String EMBEDDING_MODEL_ID_FIELD = "embedding_model_id";
+    public static final String INDEX_FIELD = "index";
+    public static final String SOURCE_FIELD = "source_field";
+    public static final String DOC_SIZE_FIELD = "doc_size";
     public static final String EMBEDDING_FIELD = "embedding_field";
     public static final String OUTPUT_FIELD = "output_field";
     public static final String QUERY_TYPE = "query_type";
+    public static final String CONTENT_GENERATION_FIELD = "enable_Content_Generation";
     public static final String K_FIELD = "k";
     private final AbstractRetrieverTool queryTool;
     private String name = TYPE;
     private String description = DEFAULT_DESCRIPTION;
     private Client client;
     private String inferenceModelId;
+    private Boolean enableContentGeneration;
     private NamedXContentRegistry xContentRegistry;
-    private String index;
-    private String embeddingField;
-    private String[] sourceFields;
-    private String embeddingModelId;
     private String queryType;
-    private Integer docSize;
-    private Integer k;
     @Setter
     private Parser inputParser;
     @Setter
@@ -76,27 +75,14 @@ public class RAGTool extends AbstractRetrieverTool {
     public RAGTool(
         Client client,
         NamedXContentRegistry xContentRegistry,
-        String index,
-        String embeddingField,
-        String[] sourceFields,
-        Integer k,
-        Integer docSize,
-        String embeddingModelId,
         String inferenceModelId,
-        String queryType,
+        Boolean enableContentGeneration,
         AbstractRetrieverTool queryTool
     ) {
-        super(client, xContentRegistry, index, sourceFields, docSize);
         this.client = client;
         this.xContentRegistry = xContentRegistry;
-        this.index = index;
-        this.embeddingField = embeddingField;
-        this.sourceFields = sourceFields;
-        this.embeddingModelId = embeddingModelId;
-        this.docSize = docSize == null ? DEFAULT_DOC_SIZE : docSize;
-        this.k = k == null ? DEFAULT_K : k;
         this.inferenceModelId = inferenceModelId;
-        this.queryType = queryType;
+        this.enableContentGeneration = enableContentGeneration;
         this.queryTool = queryTool;
         outputParser = new Parser() {
             @Override
@@ -107,13 +93,6 @@ public class RAGTool extends AbstractRetrieverTool {
         };
     }
 
-    // getQueryBody is not used in RAGTool
-    @Override
-    protected String getQueryBody(String queryText) {
-        return queryText;
-    }
-
-    @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
         String input = null;
 
@@ -132,7 +111,9 @@ public class RAGTool extends AbstractRetrieverTool {
         String embeddingInput = input;
         ActionListener actionListener = ActionListener.<T>wrap(r -> {
             T queryToolOutput;
-
+            if (!this.enableContentGeneration) {
+                listener.onResponse(r);
+            }
             if (r.equals("Can not get any match from search result.")) {
                 queryToolOutput = (T) "";
             } else {
@@ -155,25 +136,15 @@ public class RAGTool extends AbstractRetrieverTool {
             Map<String, String> tmpParameters = new HashMap<>();
             tmpParameters.putAll(parameters);
 
-            if (queryToolOutput instanceof List
-                && !((List) queryToolOutput).isEmpty()
-                && ((List) queryToolOutput).get(0) instanceof ModelTensors) {
-                ModelTensors tensors = (ModelTensors) ((List) queryToolOutput).get(0);
-                Object response = tensors.getMlModelTensors().get(0).getDataAsMap().get("response");
-                tmpParameters.put(OUTPUT_FIELD, response + "");
-            } else if (queryToolOutput instanceof ModelTensor) {
-                tmpParameters.put(OUTPUT_FIELD, escapeJson(toJson(((ModelTensor) queryToolOutput).getDataAsMap())));
+            if (queryToolOutput instanceof String) {
+                tmpParameters.put(OUTPUT_FIELD, (String) queryToolOutput);
             } else {
-                if (queryToolOutput instanceof String) {
-                    tmpParameters.put(OUTPUT_FIELD, (String) queryToolOutput);
-                } else {
-                    tmpParameters.put(OUTPUT_FIELD, escapeJson(toJson(queryToolOutput.toString())));
-                }
+                tmpParameters.put(OUTPUT_FIELD, escapeJson(toJson(queryToolOutput.toString())));
             }
 
             RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet.builder().parameters(tmpParameters).build();
             MLInput mlInput = MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataSet).build();
-            ActionRequest request = new MLPredictionTaskRequest(inferenceModelId, mlInput, null);
+            ActionRequest request = new MLPredictionTaskRequest(this.inferenceModelId, mlInput, null);
 
             client.execute(MLPredictionTaskAction.INSTANCE, request, ActionListener.wrap(resp -> {
                 ModelTensorOutput modelTensorOutput = (ModelTensorOutput) resp.getOutput();
@@ -184,32 +155,33 @@ public class RAGTool extends AbstractRetrieverTool {
                     listener.onResponse((T) outputParser.parse(modelTensorOutput.getMlModelOutputs()));
                 }
             }, e -> {
-                log.error("Failed to run model " + inferenceModelId, e);
+                log.error("Failed to run model " + this.inferenceModelId, e);
                 listener.onFailure(e);
             }));
         }, e -> {
             log.error("Failed to search index.", e);
             listener.onFailure(e);
         });
-        this.queryTool.run(Map.of(VectorDBTool.INPUT_FIELD, embeddingInput), actionListener);
+        this.queryTool.run(Map.of(INPUT_FIELD, embeddingInput), actionListener);
     }
 
-    @Override
     public String getType() {
         return TYPE;
     }
 
     @Override
+    public String getVersion() {
+        return null;
+    }
+
     public String getName() {
         return this.name;
     }
 
-    @Override
     public void setName(String s) {
         this.name = s;
     }
 
-    @Override
     public boolean validate(Map<String, String> parameters) {
         if (parameters == null || parameters.size() == 0) {
             return false;
@@ -247,15 +219,12 @@ public class RAGTool extends AbstractRetrieverTool {
 
         @Override
         public RAGTool create(Map<String, Object> params) {
-            String embeddingModelId = (String) params.get(EMBEDDING_MODEL_ID_FIELD);
-            String index = (String) params.get(INDEX_FIELD);
-            String embeddingField = (String) params.get(EMBEDDING_FIELD);
-            String[] sourceFields = gson.fromJson((String) params.get(SOURCE_FIELD), String[].class);
-            String inferenceModelId = (String) params.get(INFERENCE_MODEL_ID_FIELD);
-            Integer docSize = params.containsKey(DOC_SIZE_FIELD) ? Integer.parseInt((String) params.get(DOC_SIZE_FIELD)) : 2;
             String queryType = params.containsKey(QUERY_TYPE) ? (String) params.get(QUERY_TYPE) : "neural";
-            Integer k = params.containsKey(K_FIELD) ? Integer.parseInt((String) params.get(K_FIELD)) : DEFAULT_K;
-            ;
+            String embeddingModelId = (String) params.get(EMBEDDING_MODEL_ID_FIELD);
+            Boolean enableContentGeneration = params.containsKey(CONTENT_GENERATION_FIELD)
+                ? Boolean.parseBoolean((String) params.get(CONTENT_GENERATION_FIELD))
+                : true;
+            String inferenceModelId = enableContentGeneration ? (String) params.get(INFERENCE_MODEL_ID_FIELD) : "";
             switch (queryType) {
                 case "neural_sparse":
                     NeuralSparseSearchTool.Factory.getInstance().init(client, xContentRegistry);
@@ -264,32 +233,20 @@ public class RAGTool extends AbstractRetrieverTool {
                         .builder()
                         .client(client)
                         .xContentRegistry(xContentRegistry)
-                        .index(index)
-                        .embeddingField(embeddingField)
-                        .sourceFields(sourceFields)
-                        .embeddingModelId(embeddingModelId)
-                        .k(k)
-                        .docSize(docSize)
                         .inferenceModelId(inferenceModelId)
-                        .queryType(queryType)
+                        .enableContentGeneration(enableContentGeneration)
                         .queryTool(neuralSparseSearchTool)
                         .build();
                 case "neural":
                     VectorDBTool.Factory.getInstance().init(client, xContentRegistry);
-                    params.put(VectorDBTool.MODEL_ID_FIELD, EMBEDDING_MODEL_ID_FIELD);
+                    params.put(VectorDBTool.MODEL_ID_FIELD, embeddingModelId);
                     VectorDBTool vectorDBTool = VectorDBTool.Factory.getInstance().create(params);
                     return RAGTool
                         .builder()
                         .client(client)
                         .xContentRegistry(xContentRegistry)
-                        .index(index)
-                        .embeddingField(embeddingField)
-                        .sourceFields(sourceFields)
-                        .embeddingModelId(embeddingModelId)
-                        .k(k)
-                        .docSize(docSize)
                         .inferenceModelId(inferenceModelId)
-                        .queryType(queryType)
+                        .enableContentGeneration(enableContentGeneration)
                         .queryTool(vectorDBTool)
                         .build();
                 default:

--- a/src/main/java/org/opensearch/agent/tools/RAGTool.java
+++ b/src/main/java/org/opensearch/agent/tools/RAGTool.java
@@ -193,7 +193,7 @@ public class RAGTool implements Tool {
     /**
      * Factory class to create RAGTool
      */
-    public static class Factory extends AbstractRetrieverTool.Factory<RAGTool> {
+    public static class Factory implements Tool.Factory<RAGTool> {
         private Client client;
         private NamedXContentRegistry xContentRegistry;
 
@@ -227,7 +227,7 @@ public class RAGTool implements Tool {
             String inferenceModelId = enableContentGeneration ? (String) params.get(INFERENCE_MODEL_ID_FIELD) : "";
             switch (queryType) {
                 case "neural_sparse":
-                    NeuralSparseSearchTool.Factory.getInstance().init(client, xContentRegistry);
+                    params.put(NeuralSparseSearchTool.MODEL_ID_FIELD, embeddingModelId);
                     NeuralSparseSearchTool neuralSparseSearchTool = NeuralSparseSearchTool.Factory.getInstance().create(params);
                     return RAGTool
                         .builder()
@@ -238,7 +238,6 @@ public class RAGTool implements Tool {
                         .queryTool(neuralSparseSearchTool)
                         .build();
                 case "neural":
-                    VectorDBTool.Factory.getInstance().init(client, xContentRegistry);
                     params.put(VectorDBTool.MODEL_ID_FIELD, embeddingModelId);
                     VectorDBTool vectorDBTool = VectorDBTool.Factory.getInstance().create(params);
                     return RAGTool

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -128,5 +128,10 @@ public class VectorDBTool extends AbstractRetrieverTool {
         public String getDefaultVersion() {
             return null;
         }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
     }
 }

--- a/src/test/java/org/opensearch/agent/tools/RAGToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/RAGToolTests.java
@@ -91,7 +91,8 @@ public class RAGToolTests {
         client = mock(Client.class);
         listener = mock(ActionListener.class);
         RAGTool.Factory.getInstance().init(client, TEST_XCONTENT_REGISTRY_FOR_NEURAL_QUERY);
-
+        VectorDBTool.Factory.getInstance().init(client, TEST_XCONTENT_REGISTRY_FOR_NEURAL_QUERY);
+        NeuralSparseSearchTool.Factory.getInstance().init(client, TEST_XCONTENT_REGISTRY_FOR_NEURAL_QUERY);
         params = new HashMap<>();
         params.put(RAGTool.INDEX_FIELD, TEST_INDEX);
         params.put(RAGTool.EMBEDDING_FIELD, TEST_EMBEDDING_FIELD);

--- a/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
@@ -48,7 +48,7 @@ public class VectorDBToolTests {
         assertEquals(TEST_K, tool.getK());
         assertEquals("VectorDBTool", tool.getType());
         assertEquals("VectorDBTool", tool.getName());
-        assertEquals("Use this tool to search data in OpenSearch index.", VectorDBTool.Factory.getInstance().getDefaultDescription());
+        assertEquals(VectorDBTool.DEFAULT_DESCRIPTION, VectorDBTool.Factory.getInstance().getDefaultDescription());
     }
 
     @Test

--- a/src/test/resources/org/opensearch/agent/tools/neural_sparse_tool_search_response.json
+++ b/src/test/resources/org/opensearch/agent/tools/neural_sparse_tool_search_response.json
@@ -1,0 +1,71 @@
+{
+  "took" : 688,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 2,
+      "relation" : "eq"
+    },
+    "max_score" : 30.0029,
+    "hits" : [
+      {
+        "_index" : "my-nlp-index",
+        "_id" : "1",
+        "_score" : 30.0029,
+        "_source" : {
+          "passage_text" : "Hello world",
+          "passage_embedding" : {
+            "!" : 0.8708904,
+            "door" : 0.8587369,
+            "hi" : 2.3929274,
+            "worlds" : 2.7839446,
+            "yes" : 0.75845814,
+            "##world" : 2.5432441,
+            "born" : 0.2682308,
+            "nothing" : 0.8625516,
+            "goodbye" : 0.17146169,
+            "greeting" : 0.96817183,
+            "birth" : 1.2788506,
+            "come" : 0.1623208,
+            "global" : 0.4371151,
+            "it" : 0.42951578,
+            "life" : 1.5750692,
+            "thanks" : 0.26481047,
+            "world" : 4.7300377,
+            "tiny" : 0.5462298,
+            "earth" : 2.6555297,
+            "universe" : 2.0308156,
+            "worldwide" : 1.3903781,
+            "hello" : 6.696973,
+            "so" : 0.20279501,
+            "?" : 0.67785245
+          },
+          "id" : "s1"
+        }
+      },
+      {
+        "_index" : "my-nlp-index",
+        "_id" : "2",
+        "_score" : 16.480486,
+        "_source" : {
+          "passage_text" : "Hi planet",
+          "passage_embedding" : {
+            "hi" : 4.338913,
+            "planets" : 2.7755864,
+            "planet" : 5.0969057,
+            "mars" : 1.7405145,
+            "earth" : 2.6087382,
+            "hello" : 3.3210192
+          },
+          "id" : "s2"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
semantic search is based on text embedding models,  and neural sparse search is based on sparse embedding models. We are now enhancing RagTool with a parameter `query_type`, to enable both options. 

now that users can set parameter `query_type=neural` to run neural query , 
or  set parameter `query_type=neural_sparse` to run neural_sparse query  
 
 
There are two phases of RAGTool, first is through retrieval phase, to query, and second phase is content generation through inference mode. 

The newly added parameter `enable_Content_Generation`, the default is true, When it sets to false, it will return search retrieval result directly.  When it sets to true, the RAGTool will continue trigger inference model to generate content. 

Also fixing the build failure related to JDK 21 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
