### PR TITLE
Change default anomaly grade to nonzero for SearchAnomalyResultsTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -85,7 +85,7 @@ public class SearchAnomalyResultsTool implements Tool {
         final Boolean realTime = parameters.containsKey("realTime") ? Boolean.parseBoolean(parameters.get("realTime")) : null;
         final Double anomalyGradeThreshold = parameters.containsKey("anomalyGradeThreshold")
             ? Double.parseDouble(parameters.get("anomalyGradeThreshold"))
-            : null;
+            : 0;
         final Long dataStartTime = parameters.containsKey("dataStartTime") && StringUtils.isNumeric(parameters.get("dataStartTime"))
             ? Long.parseLong(parameters.get("dataStartTime"))
             : null;
@@ -115,7 +115,7 @@ public class SearchAnomalyResultsTool implements Tool {
             mustList.add(boolQuery);
         }
         if (anomalyGradeThreshold != null) {
-            mustList.add(new RangeQueryBuilder("anomaly_grade").gte(anomalyGradeThreshold));
+            mustList.add(new RangeQueryBuilder("anomaly_grade").gt(anomalyGradeThreshold));
         }
         if (dataStartTime != null || dataEndTime != null) {
             RangeQueryBuilder rangeQuery = new RangeQueryBuilder("anomaly_grade");


### PR DESCRIPTION
### Description
Tunes the default anomaly grade to be > 0, so only anomalies are returned by default instead of all anomaly results (which includes all non-anomalous datapoints as well).
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
