### PR TITLE
Fix the flaky test due to m_l_limit_exceeded_exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: 
-          - 11
-          - 17
-          - 21.0.1
+        java: [11, 17, 21]
     name: Build and Test skills plugin on Linux
     runs-on: ubuntu-latest
     container:
@@ -65,14 +62,14 @@ jobs:
                                ./gradlew publishToMavenLocal"
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build-MacOS:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [11, 17, 21]
 
     name: Build and Test skills Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -97,10 +94,7 @@ jobs:
   build-windows:
     strategy:
       matrix:
-        java: 
-          - 11
-          - 17
-          - 21.0.1
+        java: [11, 17, 21]
     name: Build and Test skills plugin on Windows
     needs: Get-CI-Image-Tag
     runs-on: windows-latest

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -136,6 +136,7 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
             if (state.equals(MLTaskState.FAILED.toString())
                 || state.equals(MLTaskState.CANCELLED.toString())
                 || state.equals(MLTaskState.COMPLETED_WITH_ERROR.toString())) {
+                logger.info("Get task response: " + responseInMap.toString());
                 fail("The task failed with state " + state);
             }
             Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -159,10 +159,8 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
     protected void deleteModel(String modelId) {
         // need to undeploy first as model can be in use
         makeRequest(client(), "POST", "/_plugins/_ml/models/" + modelId + "/_undeploy", null, (String) null, null);
-
-        // after model undeploy returns, the max interval to update model status is 3s in ml-commons CronJob.
-        Thread.sleep(3000);
-
+        // wait ml-commons CronJob update model status.
+        Thread.sleep(5000);
         makeRequest(client(), "DELETE", "/_plugins/_ml/models/" + modelId, null, (String) null, null);
     }
 

--- a/src/test/java/org/opensearch/integTest/NeuralSparseSearchToolIT.java
+++ b/src/test/java/org/opensearch/integTest/NeuralSparseSearchToolIT.java
@@ -88,6 +88,7 @@ public class NeuralSparseSearchToolIT extends BaseAgentToolsIT {
     public void tearDown() {
         super.tearDown();
         deleteExternalIndices();
+        deleteModel(modelId);
     }
 
     public void testNeuralSparseSearchToolInFlowAgent() {

--- a/src/test/java/org/opensearch/integTest/ToolIntegrationTest.java
+++ b/src/test/java/org/opensearch/integTest/ToolIntegrationTest.java
@@ -68,6 +68,11 @@ public abstract class ToolIntegrationTest extends BaseAgentToolsIT {
         server.stop(1);
     }
 
+    @After
+    public void deleteModel() {
+        deleteModel(modelId);
+    }
+
     private String setUpConnector() {
         String url = String.format(Locale.ROOT, "http://127.0.0.1:%d/invoke", server.getAddress().getPort());
         return createConnector(


### PR DESCRIPTION
### Description
In recent PRs there are flaky test due to m_l_limit_exceeded_exception. 
error log: `"error":{"root_cause":[{"type":"m_l_limit_exceeded_exception","reason":"Memory Circuit Breaker is open, please check your resources!"}],"type":"m_l_limit_exceeded_exception","reason":"Memory Circuit Breaker is open, please check your resources!"},"status":500}` [ref](https://github.com/opensearch-project/skills/actions/runs/7660776972/job/20878791576?pr=148)
This PR fix the flaky test by incrase the threshold of `jvm_heap_memory_threshold`. Add delete model for integ tests if they have deployed one.

Fix the node20 dependency issue by changing codecov to version 1.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
