### PR TITLE
Fix SearchMonitorsTool bugs; add corresponding ITs

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -245,7 +245,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
             sb.append("{");
             sb.append("id=").append(hit.getId()).append(",");
             sb.append("name=").append(hit.getSourceAsMap().get("name")).append(",");
-            sb.append("type=").append(hit.getSourceAsMap().get("type")).append(",");
+            sb.append("type=").append(hit.getSourceAsMap().get("detector_type")).append(",");
             sb.append("description=").append(hit.getSourceAsMap().get("description")).append(",");
             sb.append("index=").append(hit.getSourceAsMap().get("indices")).append(",");
             sb.append("lastUpdateTime=").append(hit.getSourceAsMap().get("last_update_time"));

--- a/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchMonitorsTool.java
@@ -20,7 +20,6 @@ import org.opensearch.client.Client;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.commons.alerting.AlertingPluginInterface;
 import org.opensearch.commons.alerting.action.SearchMonitorRequest;
-import org.opensearch.commons.alerting.model.Monitor;
 import org.opensearch.commons.alerting.model.ScheduledJob;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -194,25 +193,6 @@ public class SearchMonitorsTool implements Tool {
         }
         sb.append("]");
         sb.append("TotalMonitors=").append(hitsAsMap.size());
-        listener.onResponse((T) sb.toString());
-    }
-
-    private <T> void processGetMonitorHit(Monitor monitor, ActionListener<T> listener) {
-        StringBuilder sb = new StringBuilder();
-        if (monitor != null) {
-            sb.append("Monitors=[");
-            sb.append("{");
-            sb.append("id=").append(monitor.getId()).append(",");
-            sb.append("name=").append(monitor.getName()).append(",");
-            sb.append("type=").append(monitor.getType()).append(",");
-            sb.append("enabled=").append(monitor.getEnabled()).append(",");
-            sb.append("enabledTime=").append(monitor.getEnabledTime().toEpochMilli()).append(",");
-            sb.append("lastUpdateTime=").append(monitor.getLastUpdateTime().toEpochMilli());
-            sb.append("}]");
-            sb.append("TotalMonitors=1");
-        } else {
-            sb.append("Monitors=[]TotalMonitors=0");
-        }
         listener.onResponse((T) sb.toString());
     }
 

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -117,7 +117,7 @@ public class SearchAnomalyDetectorsToolTests {
         XContentBuilder content = XContentBuilder.builder(XContentType.JSON.xContent());
         content.startObject();
         content.field("name", testDetector.getName());
-        content.field("type", testDetector.getDetectorType());
+        content.field("detector_type", testDetector.getDetectorType());
         content.field("description", testDetector.getDescription());
         content.field("indices", testDetector.getIndices().get(0));
         content.field("last_update_time", testDetector.getLastUpdateTime().toEpochMilli());

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -115,6 +115,13 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
         return parseFieldFromResponse(response, MLTask.TASK_ID_FIELD).toString();
     }
 
+    protected String indexMonitor(String monitorAsJsonString) {
+        Response response = makeRequest(client(), "POST", "_plugins/_alerting/monitors", null, monitorAsJsonString, null);
+
+        assertEquals(RestStatus.CREATED, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return parseFieldFromResponse(response, "_id").toString();
+    }
+
     @SneakyThrows
     protected Map<String, Object> waitTaskComplete(String taskId) {
         for (int i = 0; i < MAX_TASK_RESULT_QUERY_TIME_IN_SECOND; i++) {

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -9,16 +9,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 
 import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public class SearchMonitorsToolIT extends BaseAgentToolsIT {
     private String registerAgentRequestBody;
-    private static final String monitorId = "foo-id";
     private static final String monitorName = "foo-name";
+    private static final String monitorName2 = "bar-name";
 
     @Before
     @SneakyThrows
@@ -54,5 +60,86 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
         assertEquals("Monitors=[]TotalMonitors=0", result);
     }
 
-    // TODO: Add IT to test against sample monitor data
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_searchById() {
+        deleteSystemIndices();
+        String monitorId = indexMonitor(getMonitorJsonString(monitorName, true));
+
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"monitorId\": \"" + monitorId + "\"}}";
+
+        String result = executeAgent(agentId, agentInput);
+        assertTrue(result.contains(String.format("name=%s", monitorName)));
+        assertTrue(result.contains("TotalMonitors=1"));
+    }
+
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_singleMonitor_noFilter() {
+        deleteSystemIndices();
+        indexMonitor(getMonitorJsonString(monitorName, true));
+
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{}}";
+        String result = executeAgent(agentId, agentInput);
+        assertTrue(result.contains(String.format("name=%s", monitorName)));
+        assertTrue(result.contains("TotalMonitors=1"));
+    }
+
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_singleMonitor_filter() {
+        deleteSystemIndices();
+
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"monitorId\": \"" + "foo-id" + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertTrue(result.contains("TotalMonitors=0"));
+    }
+
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_multipleMonitors_noFilter() {
+        deleteSystemIndices();
+        indexMonitor(getMonitorJsonString(monitorName, true));
+        indexMonitor(getMonitorJsonString(monitorName2, false));
+
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{}}";
+        String result = executeAgent(agentId, agentInput);
+        assertTrue(result.contains(String.format("name=%s", monitorName)));
+        assertTrue(result.contains(String.format("name=%s", monitorName2)));
+        assertTrue(result.contains("enabled=true"));
+        assertTrue(result.contains("enabled=false"));
+        assertTrue(result.contains("TotalMonitors=2"));
+    }
+
+    @SneakyThrows
+    public void testSearchMonitorsToolInFlowAgent_multipleMonitors_filter() {
+        deleteSystemIndices();
+        indexMonitor(getMonitorJsonString(monitorName, true));
+        indexMonitor(getMonitorJsonString(monitorName2, false));
+
+        String agentId = createAgent(registerAgentRequestBody);
+        String agentInput = "{\"parameters\":{\"monitorName\": \"" + monitorName + "\"}}";
+        String result = executeAgent(agentId, agentInput);
+        assertTrue(result.contains(String.format("name=%s", monitorName)));
+        assertFalse(result.contains(String.format("name=%s", monitorName2)));
+        assertTrue(result.contains("enabled=true"));
+        assertTrue(result.contains("TotalMonitors=1"));
+    }
+
+    // Helper fn to create the JSON string to use in a REST request body when indexing a monitor
+    private String getMonitorJsonString(String monitorName, boolean enabled) {
+        JSONObject jsonObj = new JSONObject();
+        jsonObj.put("type", "monitor");
+        jsonObj.put("name", monitorName);
+        jsonObj.put("enabled", String.valueOf(enabled));
+        jsonObj.put("inputs", Collections.emptyList());
+        jsonObj.put("triggers", Collections.emptyList());
+        Map scheduleMap = new HashMap<String, Object>();
+        Map periodMap = new HashMap<String, Object>();
+        periodMap.put("interval", 5);
+        periodMap.put("unit", "MINUTES");
+        scheduleMap.put("period", periodMap);
+        jsonObj.put("schedule", scheduleMap);
+        return jsonObj.toString();
+    }
 }

--- a/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchMonitorsToolIT.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
@@ -43,6 +44,12 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
             );
     }
 
+    @BeforeEach
+    @SneakyThrows
+    public void prepareTest() {
+        deleteSystemIndices();
+    }
+
     @After
     @SneakyThrows
     public void tearDown() {
@@ -53,7 +60,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_withNoSystemIndex() {
-        deleteSystemIndices();
         String agentId = createAgent(registerAgentRequestBody);
         String agentInput = "{\"parameters\":{\"monitorName\": \"" + monitorName + "\"}}";
         String result = executeAgent(agentId, agentInput);
@@ -62,7 +68,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_searchById() {
-        deleteSystemIndices();
         String monitorId = indexMonitor(getMonitorJsonString(monitorName, true));
 
         String agentId = createAgent(registerAgentRequestBody);
@@ -75,7 +80,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_singleMonitor_noFilter() {
-        deleteSystemIndices();
         indexMonitor(getMonitorJsonString(monitorName, true));
 
         String agentId = createAgent(registerAgentRequestBody);
@@ -87,8 +91,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_singleMonitor_filter() {
-        deleteSystemIndices();
-
         String agentId = createAgent(registerAgentRequestBody);
         String agentInput = "{\"parameters\":{\"monitorId\": \"" + "foo-id" + "\"}}";
         String result = executeAgent(agentId, agentInput);
@@ -97,7 +99,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_multipleMonitors_noFilter() {
-        deleteSystemIndices();
         indexMonitor(getMonitorJsonString(monitorName, true));
         indexMonitor(getMonitorJsonString(monitorName2, false));
 
@@ -113,7 +114,6 @@ public class SearchMonitorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     public void testSearchMonitorsToolInFlowAgent_multipleMonitors_filter() {
-        deleteSystemIndices();
         indexMonitor(getMonitorJsonString(monitorName, true));
         indexMonitor(getMonitorJsonString(monitorName2, false));
 


### PR DESCRIPTION
### Description
This PR fixes few bugs related to the SearchMonitorsTool:
- result parsing bug where monitor fields being `null` due to discrepancy on alerting plugin's transport vs. REST action for the search monitor API. TLDR is the REST action does post-processing by removing the nested `monitor` field, hence we need to do the same thing in the tool.
- search by `monitorID` bug due to classloading issue with the `getMonitor()` fn via common-utils. Simplified the tool to only use the search monitors transport action which improves maintainability as well

Also fixes a bug in SearchAnomalyDetectorsTool where the mapping should be `detector_type` instead of `type`.
 
Also adds several IT cases to cover the bugs. Completes part of #136 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
