### PR TITLE
fix: trim index name in parameters for PPL tool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -495,8 +495,7 @@ public class PPLTool implements Tool {
         if (!StringUtils.isBlank(this.previousToolKey) && StringUtils.isBlank(indexName)) {
             indexName = parameters.getOrDefault(this.previousToolKey + ".output", ""); // read index name from previous key
         }
-        return indexName;
-
+        return indexName.trim();
     }
 
     private static Map<String, String> loadDefaultPromptDict() throws IOException {


### PR DESCRIPTION
### Description
Bug fix: trim index name in parameters for PPL tool
 
### Issues Resolved
Sometimes the input index name contains heading or tailing spaces (like ` opensearch_dashboards_sample_data_logs`). We fix this bug by trimming index name in parameters for PPL tool.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
