### PR TITLE
feat: use original input for RAGTool / VectorDBTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -50,6 +50,11 @@ public abstract class AbstractRetrieverTool implements Tool {
     protected Integer docSize;
     protected String version;
 
+    @Override
+    public boolean useOriginalInput() {
+        return true;
+    }
+
     protected AbstractRetrieverTool(
         Client client,
         NamedXContentRegistry xContentRegistry,

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -50,11 +50,6 @@ public abstract class AbstractRetrieverTool implements Tool {
     protected Integer docSize;
     protected String version;
 
-    @Override
-    public boolean useOriginalInput() {
-        return true;
-    }
-
     protected AbstractRetrieverTool(
         Client client,
         NamedXContentRegistry xContentRegistry,

--- a/src/main/java/org/opensearch/agent/tools/RAGTool.java
+++ b/src/main/java/org/opensearch/agent/tools/RAGTool.java
@@ -71,6 +71,11 @@ public class RAGTool implements Tool {
     @Setter
     private Parser outputParser;
 
+    @Override
+    public boolean useOriginalInput() {
+        return true;
+    }
+
     @Builder
     public RAGTool(
         Client client,

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -41,6 +41,11 @@ public class VectorDBTool extends AbstractRetrieverTool {
     private String embeddingField;
     private Integer k;
 
+    @Override
+    public boolean useOriginalInput() {
+        return true;
+    }
+
     @Builder
     public VectorDBTool(
         Client client,


### PR DESCRIPTION
### Description
In conversational agent, LLM is transforming user's input to other input like JSON / DSL query etc. So for VectorDBTool / RAGTool, we need to keep original input.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
