### PR TITLE
Fix alert constructor

### DIFF
--- a/src/test/java/org/opensearch/agent/tools/SearchAlertsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAlertsToolTests.java
@@ -108,7 +108,8 @@ public class SearchAlertsToolTests {
             Collections.emptyList(),
             null,
             null,
-            Collections.emptyList()
+            Collections.emptyList(),
+            null
         );
         Alert alert2 = new Alert(
             "alert-id-2",
@@ -135,7 +136,8 @@ public class SearchAlertsToolTests {
             Collections.emptyList(),
             null,
             null,
-            Collections.emptyList()
+            Collections.emptyList(),
+            null
         );
         List<Alert> mockAlerts = List.of(alert1, alert2);
 

--- a/src/test/resources/org/opensearch/agent/tools/alerting/alert_index_mappings.json
+++ b/src/test/resources/org/opensearch/agent/tools/alerting/alert_index_mappings.json
@@ -167,6 +167,14 @@
                         "type": "text"
                     }
                 }
+            },
+            "clusters": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword"
+                    }
+                }
             }
         }
     }

--- a/src/test/resources/org/opensearch/agent/tools/alerting/sample_alert.json
+++ b/src/test/resources/org/opensearch/agent/tools/alerting/sample_alert.json
@@ -19,5 +19,6 @@
     "start_time": 1234,
     "last_notification_time": 1234,
     "end_time": 1234,
-    "acknowledged_time": null
+    "acknowledged_time": null,
+    "clusters": ""
 }

--- a/src/test/resources/org/opensearch/agent/tools/alerting/sample_alert.json
+++ b/src/test/resources/org/opensearch/agent/tools/alerting/sample_alert.json
@@ -20,5 +20,5 @@
     "last_notification_time": 1234,
     "end_time": 1234,
     "acknowledged_time": null,
-    "clusters": ""
+    "clusters": []
 }


### PR DESCRIPTION
### Description
Fix `Alert` constructor caused by this breaking change from alerting team. https://github.com/opensearch-project/common-utils/pull/584
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
