### PR TITLE
Fix SearchAnomalyDetectorsTool indices param bug; add more IT

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -28,6 +28,8 @@ import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -116,7 +118,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
             mustList.add(new WildcardQueryBuilder("name.keyword", detectorNamePattern));
         }
         if (indices != null) {
-            mustList.add(new TermQueryBuilder("indices", indices));
+            mustList.add(new MatchQueryBuilder("indices", indices).operator(Operator.AND));
         }
         if (highCardinality != null) {
             mustList.add(new TermQueryBuilder("detector_type", highCardinality ? "MULTI_ENTITY" : "SINGLE_ENTITY"));

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -29,7 +29,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
-import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -118,7 +117,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
             mustList.add(new WildcardQueryBuilder("name.keyword", detectorNamePattern));
         }
         if (indices != null) {
-            mustList.add(new MatchQueryBuilder("indices", indices).operator(Operator.AND));
+            mustList.add(new MatchQueryBuilder("indices", indices).analyzer("keyword"));
         }
         if (highCardinality != null) {
             mustList.add(new TermQueryBuilder("detector_type", highCardinality ? "MULTI_ENTITY" : "SINGLE_ENTITY"));

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -28,7 +28,6 @@ import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -117,7 +116,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
             mustList.add(new WildcardQueryBuilder("name.keyword", detectorNamePattern));
         }
         if (indices != null) {
-            mustList.add(new MatchQueryBuilder("indices", indices).analyzer("keyword"));
+            mustList.add(new TermQueryBuilder("indices.keyword", indices));
         }
         if (highCardinality != null) {
             mustList.add(new TermQueryBuilder("detector_type", highCardinality ? "MULTI_ENTITY" : "SINGLE_ENTITY"));

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -59,46 +59,126 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     @Order(2)
-    public void testSearchAnomalyDetectorsToolInFlowAgent_noMatching() {
-        setupTestDetectionIndex("test-index");
-        String detectorId = ingestSampleDetector(detectorName, "test-index");
-        String agentId = createAgent(registerAgentRequestBody);
-        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
-        String result = executeAgent(agentId, agentInput);
-        assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
-        deleteDetector(detectorId);
+    public void testSearchAnomalyDetectorsToolInFlowAgent_detectorNameParam() {
+        String detectorId = "";
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "foo" + "\"}}";
+            String result = executeAgent(agentId, agentInput);
+            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+
+            String agentInput2 = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
+            String result2 = executeAgent(agentId, agentInput2);
+            assertTrue(result2.contains(String.format("id=%s", detectorId)));
+            assertTrue(result2.contains(String.format("name=%s", detectorName)));
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+        }
     }
 
     @SneakyThrows
     @Order(3)
-    public void testSearchAnomalyDetectorsToolInFlowAgent_matching() {
-        setupTestDetectionIndex("test-index");
-        String detectorId = ingestSampleDetector(detectorName, "test-index");
-        String agentId = createAgent(registerAgentRequestBody);
-        String agentInput = "{\"parameters\":{\"detectorName\": \"" + detectorName + "\"}}";
-        String result = executeAgent(agentId, agentInput);
-        assertTrue(result.contains(String.format("id=%s", detectorId)));
-        assertTrue(result.contains(String.format("name=%s", detectorName)));
-        assertTrue(result.contains(String.format("TotalAnomalyDetectors=%d", 1)));
-        deleteDetector(detectorId);
+    public void testSearchAnomalyDetectorsToolInFlowAgent_detectorNamePatternParam() {
+        String detectorId = "";
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"detectorNamePattern\": \"" + detectorName + "foo" + "\"}}";
+            String result = executeAgent(agentId, agentInput);
+            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+
+            String agentInput2 = "{\"parameters\":{\"detectorNamePattern\": \"" + detectorName + "*" + "\"}}";
+            String result2 = executeAgent(agentId, agentInput2);
+            assertTrue(result2.contains(String.format("id=%s", detectorId)));
+            assertTrue(result2.contains(String.format("name=%s", detectorName)));
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+        }
+
     }
 
     @SneakyThrows
     @Order(4)
+    public void testSearchAnomalyDetectorsToolInFlowAgent_indicesParam() {
+        String detectorId = "";
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"indices\": \"test-index-foo\"}}";
+            String result = executeAgent(agentId, agentInput);
+            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+
+            String agentInput2 = "{\"parameters\":{\"indices\": \"test-index\"}}";
+            String result2 = executeAgent(agentId, agentInput2);
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+        }
+
+    }
+
+    @SneakyThrows
+    @Order(5)
+    public void testSearchAnomalyDetectorsToolInFlowAgent_highCardinalityParam() {
+        String detectorId = "";
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"highCardinality\": \"true\"}}";
+            String result = executeAgent(agentId, agentInput);
+            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+
+            String agentInput2 = "{\"parameters\":{\"highCardinality\": \"false\"}}";
+            String result2 = executeAgent(agentId, agentInput2);
+            assertTrue(result2.contains(String.format("id=%s", detectorId)));
+            assertTrue(result2.contains(String.format("name=%s", detectorName)));
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+        }
+
+    }
+
+    @SneakyThrows
+    @Order(6)
     public void testSearchAnomalyDetectorsToolInFlowAgent_complexParams() {
-        setupTestDetectionIndex("test-index");
-        String detectorId = ingestSampleDetector(detectorName, "test-index");
-        String detectorIdFoo = ingestSampleDetector(detectorName + "foo", "test-index");
-        String agentId = createAgent(registerAgentRequestBody);
-        String agentInput = "{\"parameters\":{\"detectorName\": \""
-            + detectorName
-            + "\", \"highCardinality\": false, \"sortOrder\": \"asc\", \"sortString\": \"name.keyword\", \"size\": 10, \"startIndex\": 0 }}";
-        String result = executeAgent(agentId, agentInput);
-        assertTrue(result.contains(String.format("id=%s", detectorId)));
-        assertTrue(result.contains(String.format("name=%s", detectorName)));
-        assertTrue(result.contains(String.format("TotalAnomalyDetectors=%d", 1)));
-        deleteDetector(detectorId);
-        deleteDetector(detectorIdFoo);
+        String detectorId = null;
+        String detectorIdFoo = null;
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            detectorIdFoo = ingestSampleDetector(detectorName + "foo", "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"detectorName\": \""
+                + detectorName
+                + "\", \"highCardinality\": false, \"sortOrder\": \"asc\", \"sortString\": \"name.keyword\", \"size\": 10, \"startIndex\": 0 }}";
+            String result = executeAgent(agentId, agentInput);
+            assertTrue(result.contains(String.format("id=%s", detectorId)));
+            assertTrue(result.contains(String.format("name=%s", detectorName)));
+            assertTrue(result.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+            if (detectorIdFoo != null) {
+                deleteDetector(detectorIdFoo);
+            }
+        }
     }
 
     @SneakyThrows

--- a/src/test/resources/org/opensearch/agent/tools/alerting/register_flow_agent_of_search_alerts_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/alerting/register_flow_agent_of_search_alerts_tool_request_body.json
@@ -3,8 +3,7 @@
   "type": "flow",
   "tools": [
     {
-      "type": "SearchAlertsTool",
-      "description": "Use this tool to search alerts."
+      "type": "SearchAlertsTool"
     }
   ]
 }

--- a/src/test/resources/org/opensearch/agent/tools/alerting/register_flow_agent_of_search_monitors_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/alerting/register_flow_agent_of_search_monitors_tool_request_body.json
@@ -3,8 +3,7 @@
   "type": "flow",
   "tools": [
     {
-      "type": "SearchMonitorsTool",
-      "description": "Use this tool to search alerting monitors."
+      "type": "SearchMonitorsTool"
     }
   ]
 }

--- a/src/test/resources/org/opensearch/agent/tools/anomaly-detection/register_flow_agent_of_search_anomaly_detectors_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/anomaly-detection/register_flow_agent_of_search_anomaly_detectors_tool_request_body.json
@@ -3,8 +3,7 @@
   "type": "flow",
   "tools": [
     {
-      "type": "SearchAnomalyDetectorsTool",
-      "description": "Use this tool to search anomaly detectors."
+      "type": "SearchAnomalyDetectorsTool"
     }
   ]
 }

--- a/src/test/resources/org/opensearch/agent/tools/anomaly-detection/register_flow_agent_of_search_anomaly_results_tool_request_body.json
+++ b/src/test/resources/org/opensearch/agent/tools/anomaly-detection/register_flow_agent_of_search_anomaly_results_tool_request_body.json
@@ -3,8 +3,7 @@
   "type": "flow",
   "tools": [
     {
-      "type": "SearchAnomalyResultsTool",
-      "description": "Use this tool to search anomaly results."
+      "type": "SearchAnomalyResultsTool"
     }
   ]
 }


### PR DESCRIPTION
### Description
This PR fixes an edge case bug of the `indices` param failing for the `SearchAnomalyDetectorsTool` if the input contains hyphens (e.g., `sample-ecommerce-index`). By default this breaks term queries as this splits this up into multiple terms by the standard query analyzer. This fixes that by searching on the indices keyword instead to remove the complexity and potential failures.

Adds IT to cover this case plus adds more coverage of other params on matching / non-matching scenarios.

Additionally, cleans up the create agent request bodies to omit overriding the default tool descriptions which have much more detail.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
