### PR TITLE
Fix detector state params in SearchAnomalyDetectorsTool

### DIFF
--- a/src/main/java/org/opensearch/agent/ToolPlugin.java
+++ b/src/main/java/org/opensearch/agent/ToolPlugin.java
@@ -69,8 +69,8 @@ public class ToolPlugin extends Plugin implements MLCommonsExtension {
         SearchIndexTool.Factory.getInstance().init(client, xContentRegistry);
         RAGTool.Factory.getInstance().init(client, xContentRegistry);
         SearchAlertsTool.Factory.getInstance().init(client);
-        SearchAnomalyDetectorsTool.Factory.getInstance().init(client);
-        SearchAnomalyResultsTool.Factory.getInstance().init(client);
+        SearchAnomalyDetectorsTool.Factory.getInstance().init(client, namedWriteableRegistry);
+        SearchAnomalyResultsTool.Factory.getInstance().init(client, namedWriteableRegistry);
         SearchMonitorsTool.Factory.getInstance().init(client);
         return Collections.emptyList();
     }

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -8,6 +8,7 @@ package org.opensearch.agent.tools;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -50,7 +51,7 @@ import lombok.extern.log4j.Log4j2;
 public class SearchAnomalyDetectorsTool implements Tool {
     public static final String TYPE = "SearchAnomalyDetectorsTool";
     private static final String DEFAULT_DESCRIPTION =
-        "This is a tool that searches anomaly detectors. It takes 12 optional arguments named detectorName which is the explicit name of the detector (default is null), and detectorNamePattern which is a wildcard query to match detector name (default is null), and indices which defines the index or index pattern the detector is detecting over (default is null), and highCardinality which defines whether the anomaly detector is high cardinality (synonymous with multi-entity) of non-high-cardinality (synonymous with single-entity) (default is null, indicating both), and lastUpdateTime which defines the latest update time of the anomaly detector in epoch milliseconds (default is null), and sortOrder which defines the order of the results (options are asc or desc, and default is asc), and sortString which defines how to sort the results (default is name.keyword), and size which defines the size of the request to be returned (default is 20), and startIndex which defines the paginated index to start from (default is 0), and running which defines whether the anomaly detector is running (default is null, indicating both), and disabled which defines whether the anomaly detector is disabled (default is null, indicating both), and failed which defines whether the anomaly detector has failed (default is null, indicating both). The tool returns 2 values: a list of anomaly detectors (each containing the detector id, detector name, detector type indicating multi-entity or single-entity (where multi-entity also means high-cardinality), detector description, name of the configured index, last update time in epoch milliseconds), and the total number of anomaly detectors.";
+        "This is a tool that searches anomaly detectors. It takes 12 optional arguments named detectorName which is the explicit name of the detector (default is null), and detectorNamePattern which is a wildcard query to match detector name (default is null), and indices which defines the index or index pattern the detector is detecting over (default is null), and highCardinality which defines whether the anomaly detector is high cardinality (synonymous with multi-entity) of non-high-cardinality (synonymous with single-entity) (default is null, indicating both), and lastUpdateTime which defines the latest update time of the anomaly detector in epoch milliseconds (default is null), and sortOrder which defines the order of the results (options are asc or desc, and default is asc), and sortString which defines how to sort the results (default is name.keyword), and size which defines the size of the request to be returned (default is 20), and startIndex which defines the paginated index to start from (default is 0), and running which defines whether the anomaly detector is running (default is null, indicating both), and failed which defines whether the anomaly detector has failed (default is null, indicating both). The tool returns 2 values: a list of anomaly detectors (each containing the detector id, detector name, detector type indicating multi-entity or single-entity (where multi-entity also means high-cardinality), detector description, name of the configured index, last update time in epoch milliseconds), and the total number of anomaly detectors.";
 
     @Setter
     @Getter
@@ -106,7 +107,6 @@ public class SearchAnomalyDetectorsTool implements Tool {
         final int size = parameters.containsKey("size") ? Integer.parseInt(parameters.get("size")) : 20;
         final int startIndex = parameters.containsKey("startIndex") ? Integer.parseInt(parameters.get("startIndex")) : 0;
         final Boolean running = parameters.containsKey("running") ? Boolean.parseBoolean(parameters.get("running")) : null;
-        final Boolean disabled = parameters.containsKey("disabled") ? Boolean.parseBoolean(parameters.get("disabled")) : null;
         final Boolean failed = parameters.containsKey("failed") ? Boolean.parseBoolean(parameters.get("failed")) : null;
 
         List<QueryBuilder> mustList = new ArrayList<QueryBuilder>();
@@ -140,10 +140,16 @@ public class SearchAnomalyDetectorsTool implements Tool {
         ActionListener<SearchResponse> searchDetectorListener = ActionListener.<SearchResponse>wrap(response -> {
             StringBuilder sb = new StringBuilder();
             List<SearchHit> hits = Arrays.asList(response.getHits().getHits());
-            Map<String, SearchHit> hitsAsMap = hits.stream().collect(Collectors.toMap(SearchHit::getId, hit -> hit));
+            Map<String, SearchHit> hitsAsMap = new HashMap<>();
+            // We persist the hits map using detector name as the key. Note this is required to be unique from the AD plugin.
+            // We cannot use detector ID, because the detector in the response from the profile transport action does not include this,
+            // making it difficult to map potential hits that should be removed later on based on the profile response's detector state.
+            for (SearchHit hit : hits) {
+                hitsAsMap.put((String) hit.getSourceAsMap().get("name"), hit);
+            }
 
             // If we need to filter by detector state, make subsequent profile API calls to each detector
-            if (running != null || disabled != null || failed != null) {
+            if (running != null || failed != null) {
                 List<CompletableFuture<GetAnomalyDetectorResponse>> profileFutures = new ArrayList<>();
                 for (SearchHit hit : hits) {
                     CompletableFuture<GetAnomalyDetectorResponse> profileFuture = new CompletableFuture<GetAnomalyDetectorResponse>()
@@ -184,7 +190,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
 
                 for (GetAnomalyDetectorResponse profileResponse : profileResponses) {
                     if (profileResponse != null && profileResponse.getDetector() != null) {
-                        String detectorId = profileResponse.getDetector().getId();
+                        String responseDetectorName = profileResponse.getDetector().getName();
 
                         // We follow the existing logic as the frontend to determine overall detector state
                         // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/routes/utils/adHelpers.ts#L437
@@ -193,9 +199,7 @@ public class SearchAnomalyDetectorsTool implements Tool {
 
                         if (realtimeTask != null) {
                             String taskState = realtimeTask.getState();
-                            if (taskState.equalsIgnoreCase("CREATED")) {
-                                detectorState = DetectorStateString.Initializing.name();
-                            } else if (taskState.equalsIgnoreCase("RUNNING")) {
+                            if (taskState.equalsIgnoreCase("CREATED") || taskState.equalsIgnoreCase("RUNNING")) {
                                 detectorState = DetectorStateString.Running.name();
                             } else if (taskState.equalsIgnoreCase("INIT_FAILURE")
                                 || taskState.equalsIgnoreCase("UNEXPECTED_FAILURE")
@@ -204,12 +208,20 @@ public class SearchAnomalyDetectorsTool implements Tool {
                             }
                         }
 
-                        if ((Boolean.FALSE.equals(running) && detectorState.equals(DetectorStateString.Running.name()))
-                            || (Boolean.FALSE.equals(disabled) && detectorState.equals(DetectorStateString.Disabled.name()))
-                            || (Boolean.FALSE.equals(failed) && detectorState.equals(DetectorStateString.Failed.name()))) {
-                            hitsAsMap.remove(detectorId);
-                        }
+                        // if the detector state matches something set as "true", then don't remove
+                        boolean matchesTrueStates = (Boolean.TRUE.equals(running)
+                            && detectorState.equals(DetectorStateString.Running.name()))
+                            || (Boolean.TRUE.equals(failed) && detectorState.equals(DetectorStateString.Failed.name()));
 
+                        // if the detector state matches something set as "false", then don't remove
+                        boolean matchesFalseStates = (Boolean.FALSE.equals(running)
+                            && !detectorState.equals(DetectorStateString.Running.name()))
+                            || (Boolean.FALSE.equals(failed) && !detectorState.equals(DetectorStateString.Failed.name()));
+
+                        // if the detector state doesn't match either of these, then remove it
+                        if (!matchesTrueStates && !matchesFalseStates) {
+                            hitsAsMap.remove(responseDetectorName);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyDetectorsTool.java
@@ -208,18 +208,19 @@ public class SearchAnomalyDetectorsTool implements Tool {
                             }
                         }
 
-                        // if the detector state matches something set as "true", then don't remove
-                        boolean matchesTrueStates = (Boolean.TRUE.equals(running)
-                            && detectorState.equals(DetectorStateString.Running.name()))
-                            || (Boolean.TRUE.equals(failed) && detectorState.equals(DetectorStateString.Failed.name()));
+                        boolean includeRunning = running != null && running == true;
+                        boolean includeFailed = failed != null && failed == true;
+                        boolean isValid = true;
 
-                        // if the detector state matches something set as "false", then don't remove
-                        boolean matchesFalseStates = (Boolean.FALSE.equals(running)
-                            && !detectorState.equals(DetectorStateString.Running.name()))
-                            || (Boolean.FALSE.equals(failed) && !detectorState.equals(DetectorStateString.Failed.name()));
+                        if (detectorState.equals(DetectorStateString.Running.name())) {
+                            isValid = (running == null || running == true) && !(includeFailed && running == null);
+                        } else if (detectorState.equals(DetectorStateString.Failed.name())) {
+                            isValid = (failed == null || failed == true) && !(includeRunning && failed == null);
+                        } else if (detectorState.equals(DetectorStateString.Disabled.name())) {
+                            isValid = (running == null || running == false) && !(includeFailed && running == null);
+                        }
 
-                        // if the detector state doesn't match either of these, then remove it
-                        if (!matchesTrueStates && !matchesFalseStates) {
+                        if (!isValid) {
                             hitsAsMap.remove(responseDetectorName);
                         }
                     }

--- a/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
+++ b/src/main/java/org/opensearch/agent/tools/SearchAnomalyResultsTool.java
@@ -16,6 +16,7 @@ import org.opensearch.ad.client.AnomalyDetectionNodeClient;
 import org.opensearch.agent.tools.utils.ToolConstants;
 import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
@@ -61,9 +62,9 @@ public class SearchAnomalyResultsTool implements Tool {
     @Setter
     private Parser<?, ?> outputParser;
 
-    public SearchAnomalyResultsTool(Client client) {
+    public SearchAnomalyResultsTool(Client client, NamedWriteableRegistry namedWriteableRegistry) {
         this.client = client;
-        this.adClient = new AnomalyDetectionNodeClient(client);
+        this.adClient = new AnomalyDetectionNodeClient(client, namedWriteableRegistry);
 
         // probably keep this overridden output parser. need to ensure the output matches what's expected
         outputParser = new Parser<>() {
@@ -190,6 +191,8 @@ public class SearchAnomalyResultsTool implements Tool {
     public static class Factory implements Tool.Factory<SearchAnomalyResultsTool> {
         private Client client;
 
+        private NamedWriteableRegistry namedWriteableRegistry;
+
         private AnomalyDetectionNodeClient adClient;
 
         private static Factory INSTANCE;
@@ -214,14 +217,15 @@ public class SearchAnomalyResultsTool implements Tool {
          * Initialize this factory
          * @param client The OpenSearch client
          */
-        public void init(Client client) {
+        public void init(Client client, NamedWriteableRegistry namedWriteableRegistry) {
             this.client = client;
-            this.adClient = new AnomalyDetectionNodeClient(client);
+            this.namedWriteableRegistry = namedWriteableRegistry;
+            this.adClient = new AnomalyDetectionNodeClient(client, namedWriteableRegistry);
         }
 
         @Override
         public SearchAnomalyResultsTool create(Map<String, Object> map) {
-            return new SearchAnomalyResultsTool(client);
+            return new SearchAnomalyResultsTool(client, namedWriteableRegistry);
         }
 
         @Override

--- a/src/test/java/org/opensearch/agent/TestHelpers.java
+++ b/src/test/java/org/opensearch/agent/TestHelpers.java
@@ -41,10 +41,10 @@ public class TestHelpers {
         );
     }
 
-    public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorIds, String[] detectorStates) {
+    public static GetAnomalyDetectorResponse generateGetAnomalyDetectorResponses(String[] detectorNames, String[] detectorStates) {
         AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
         // For each subsequent call to getId(), return the next detectorId in the array
-        when(detector.getId()).thenReturn(detectorIds[0], Arrays.copyOfRange(detectorIds, 1, detectorIds.length));
+        when(detector.getName()).thenReturn(detectorNames[0], Arrays.copyOfRange(detectorNames, 1, detectorNames.length));
         ADTask realtimeAdTask = Mockito.mock(ADTask.class);
         // For each subsequent call to getState(), return the next detectorState in the array
         when(realtimeAdTask.getState()).thenReturn(detectorStates[0], Arrays.copyOfRange(detectorStates, 1, detectorStates.length));

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -156,7 +156,7 @@ public class SearchAnomalyDetectorsToolTests {
         hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
-            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+            .generateGetAnomalyDetectorResponses(new String[] { detectorName }, new String[] { DetectorStateString.Running.name() });
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
@@ -181,7 +181,7 @@ public class SearchAnomalyDetectorsToolTests {
         hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
-            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+            .generateGetAnomalyDetectorResponses(new String[] { detectorName }, new String[] { DetectorStateString.Running.name() });
         String expectedResponseStr = "AnomalyDetectors=[]TotalAnomalyDetectors=0";
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
@@ -204,7 +204,7 @@ public class SearchAnomalyDetectorsToolTests {
         hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
-            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+            .generateGetAnomalyDetectorResponses(new String[] { detectorName }, new String[] { DetectorStateString.Running.name() });
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
@@ -229,7 +229,7 @@ public class SearchAnomalyDetectorsToolTests {
         hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
-            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+            .generateGetAnomalyDetectorResponses(new String[] { detectorName }, new String[] { DetectorStateString.Running.name() });
         // Overriding the mocked response to realtime task and setting to null. This occurs when
         // a detector is created but is never started.
         when(getDetectorProfileResponse.getRealtimeAdTask()).thenReturn(null);
@@ -237,7 +237,7 @@ public class SearchAnomalyDetectorsToolTests {
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(Map.of("disabled", "true"), listener);
+        tool.run(Map.of("running", "false"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         String response = responseCaptor.getValue();
@@ -257,14 +257,14 @@ public class SearchAnomalyDetectorsToolTests {
         hits[0] = TestHelpers.generateSearchDetectorHit(detectorName, detectorId);
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
-            .generateGetAnomalyDetectorResponses(new String[] { detectorId }, new String[] { DetectorStateString.Running.name() });
+            .generateGetAnomalyDetectorResponses(new String[] { detectorName }, new String[] { DetectorStateString.Running.name() });
         // Overriding the mocked response to set realtime task state to CREATED
         when(getDetectorProfileResponse.getRealtimeAdTask().getState()).thenReturn("CREATED");
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(Map.of("running", "false"), listener);
+        tool.run(Map.of("running", "true"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         String response = responseCaptor.getValue();
@@ -291,7 +291,7 @@ public class SearchAnomalyDetectorsToolTests {
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
             .generateGetAnomalyDetectorResponses(
-                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { detectorName1, detectorName2, detectorName3 },
                 new String[] { "INIT_FAILURE", "UNEXPECTED_FAILURE", "FAILED" }
             );
         @SuppressWarnings("unchecked")
@@ -329,24 +329,22 @@ public class SearchAnomalyDetectorsToolTests {
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
             .generateGetAnomalyDetectorResponses(
-                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { detectorName1, detectorName2, detectorName3 },
                 new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
             );
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(Map.of("running", "true", "disabled", "true", "failed", "true"), listener);
+        tool.run(Map.of("running", "true", "failed", "true"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         String response = responseCaptor.getValue();
         assertTrue(response.contains(String.format("id=%s", detectorId1)));
         assertTrue(response.contains(String.format("name=%s", detectorName1)));
-        assertTrue(response.contains(String.format("id=%s", detectorId2)));
-        assertTrue(response.contains(String.format("name=%s", detectorName2)));
         assertTrue(response.contains(String.format("id=%s", detectorId3)));
         assertTrue(response.contains(String.format("name=%s", detectorName3)));
-        assertTrue(response.contains(String.format("TotalAnomalyDetectors=%d", hits.length)));
+        assertTrue(response.contains(String.format("TotalAnomalyDetectors=%d", 2)));
     }
 
     @Test
@@ -367,17 +365,17 @@ public class SearchAnomalyDetectorsToolTests {
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
             .generateGetAnomalyDetectorResponses(
-                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { detectorName1, detectorName2, detectorName3 },
                 new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
             );
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(Map.of("running", "false", "disabled", "false", "failed", "false"), listener);
+        tool.run(Map.of("running", "false", "failed", "false"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
-        assertTrue(responseCaptor.getValue().contains("TotalAnomalyDetectors=0"));
+        assertTrue(responseCaptor.getValue().contains("TotalAnomalyDetectors=1"));
     }
 
     @Test
@@ -398,22 +396,20 @@ public class SearchAnomalyDetectorsToolTests {
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         GetAnomalyDetectorResponse getDetectorProfileResponse = TestHelpers
             .generateGetAnomalyDetectorResponses(
-                new String[] { detectorId1, detectorId2, detectorId3 },
+                new String[] { detectorName1, detectorName2, detectorName3 },
                 new String[] { DetectorStateString.Running.name(), DetectorStateString.Disabled.name(), DetectorStateString.Failed.name() }
             );
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);
         mockProfileApiCalls(getDetectorsResponse, getDetectorProfileResponse);
 
-        tool.run(Map.of("running", "true", "disabled", "false", "failed", "true"), listener);
+        tool.run(Map.of("running", "true", "failed", "false"), listener);
         ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
         verify(listener, times(1)).onResponse(responseCaptor.capture());
         String response = responseCaptor.getValue();
         assertTrue(response.contains(String.format("id=%s", detectorId1)));
         assertTrue(response.contains(String.format("name=%s", detectorName1)));
-        assertTrue(response.contains(String.format("id=%s", detectorId3)));
-        assertTrue(response.contains(String.format("name=%s", detectorName3)));
-        assertTrue(response.contains(String.format("TotalAnomalyDetectors=%d", 2)));
+        assertTrue(response.contains(String.format("TotalAnomalyDetectors=%d", 1)));
     }
 
     @Test
@@ -428,7 +424,6 @@ public class SearchAnomalyDetectorsToolTests {
         validParams.put("size", "10");
         validParams.put("startIndex", "0");
         validParams.put("running", "false");
-        validParams.put("disabled", "false");
 
         @SuppressWarnings("unchecked")
         ActionListener<String> listener = Mockito.mock(ActionListener.class);

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -41,12 +41,15 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.search.SearchHit;
 import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 
 public class SearchAnomalyDetectorsToolTests {
+    @Mock
+    private NamedWriteableRegistry namedWriteableRegistry;
     @Mock
     private NodeClient nodeClient;
 
@@ -59,7 +62,7 @@ public class SearchAnomalyDetectorsToolTests {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        SearchAnomalyDetectorsTool.Factory.getInstance().init(nodeClient);
+        SearchAnomalyDetectorsTool.Factory.getInstance().init(nodeClient, namedWriteableRegistry);
 
         nullParams = null;
         emptyParams = Collections.emptyMap();

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyResultsToolTests.java
@@ -33,13 +33,11 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.agent.tools.utils.ToolConstants;
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.ClusterAdminClient;
-import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.search.SearchHit;
@@ -48,13 +46,9 @@ import org.opensearch.search.aggregations.Aggregations;
 
 public class SearchAnomalyResultsToolTests {
     @Mock
+    private NamedWriteableRegistry namedWriteableRegistry;
+    @Mock
     private NodeClient nodeClient;
-    @Mock
-    private AdminClient adminClient;
-    @Mock
-    private IndicesAdminClient indicesAdminClient;
-    @Mock
-    private ClusterAdminClient clusterAdminClient;
 
     private Map<String, String> nullParams;
     private Map<String, String> emptyParams;
@@ -63,7 +57,7 @@ public class SearchAnomalyResultsToolTests {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        SearchAnomalyResultsTool.Factory.getInstance().init(nodeClient);
+        SearchAnomalyResultsTool.Factory.getInstance().init(nodeClient, namedWriteableRegistry);
 
         nullParams = null;
         emptyParams = Collections.emptyMap();

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -138,6 +138,30 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
         return parseFieldFromResponse(response, "_id").toString();
     }
 
+    protected void startDetector(String detectorId) {
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "_plugins/_anomaly_detection/detectors/" + detectorId + "/_start",
+            null,
+            (String) null,
+            null
+        );
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    protected void stopDetector(String detectorId) {
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "_plugins/_anomaly_detection/detectors/" + detectorId + "/_stop",
+            null,
+            (String) null,
+            null
+        );
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
     protected void deleteDetector(String detectorId) {
         Response response = makeRequest(
             client(),

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -60,7 +60,7 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     @SneakyThrows
     @Order(2)
     public void testSearchAnomalyDetectorsToolInFlowAgent_detectorNameParam() {
-        String detectorId = "";
+        String detectorId = null;
         try {
             setupTestDetectionIndex("test-index");
             detectorId = ingestSampleDetector(detectorName, "test-index");
@@ -84,7 +84,7 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     @SneakyThrows
     @Order(3)
     public void testSearchAnomalyDetectorsToolInFlowAgent_detectorNamePatternParam() {
-        String detectorId = "";
+        String detectorId = null;
         try {
             setupTestDetectionIndex("test-index");
             detectorId = ingestSampleDetector(detectorName, "test-index");
@@ -109,7 +109,7 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     @SneakyThrows
     @Order(4)
     public void testSearchAnomalyDetectorsToolInFlowAgent_indicesParam() {
-        String detectorId = "";
+        String detectorId = null;
         try {
             setupTestDetectionIndex("test-index");
             detectorId = ingestSampleDetector(detectorName, "test-index");
@@ -132,7 +132,7 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
     @SneakyThrows
     @Order(5)
     public void testSearchAnomalyDetectorsToolInFlowAgent_highCardinalityParam() {
-        String detectorId = "";
+        String detectorId = null;
         try {
             setupTestDetectionIndex("test-index");
             detectorId = ingestSampleDetector(detectorName, "test-index");
@@ -156,24 +156,52 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     @Order(6)
-    public void testSearchAnomalyDetectorsToolInFlowAgent_runningParam() {
-        String detectorId = "";
+    public void testSearchAnomalyDetectorsToolInFlowAgent_detectorStateParams() {
+        String detectorIdRunning = null;
+        String detectorIdDisabled1 = null;
+        String detectorIdDisabled2 = null;
         try {
+            // TODO: update test scenarios
             setupTestDetectionIndex("test-index");
-            detectorId = ingestSampleDetector(detectorName, "test-index");
+            detectorIdRunning = ingestSampleDetector(detectorName + "-running", "test-index");
+            detectorIdDisabled1 = ingestSampleDetector(detectorName + "-disabled-1", "test-index");
+            detectorIdDisabled2 = ingestSampleDetector(detectorName + "-disabled-2", "test-index");
+            startDetector(detectorIdRunning);
+            Thread.sleep(5000);
+
             String agentId = createAgent(registerAgentRequestBody);
             String agentInput = "{\"parameters\":{\"running\": \"true\"}}";
             String result = executeAgent(agentId, agentInput);
-            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+            assertTrue(result.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+            assertTrue(result.contains(detectorIdRunning));
 
             String agentInput2 = "{\"parameters\":{\"running\": \"false\"}}";
             String result2 = executeAgent(agentId, agentInput2);
-            assertTrue(result2.contains(String.format("id=%s", detectorId)));
-            assertTrue(result2.contains(String.format("name=%s", detectorName)));
-            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 2)));
+            assertTrue(result2.contains(detectorIdDisabled1));
+            assertTrue(result2.contains(detectorIdDisabled2));
+
+            String agentInput3 = "{\"parameters\":{\"failed\": \"true\"}}";
+            String result3 = executeAgent(agentId, agentInput3);
+            assertTrue(result3.contains(String.format("TotalAnomalyDetectors=%d", 0)));
+
+            String agentInput4 = "{\"parameters\":{\"failed\": \"false\"}}";
+            String result4 = executeAgent(agentId, agentInput4);
+            assertTrue(result4.contains(String.format("TotalAnomalyDetectors=%d", 3)));
+            assertTrue(result4.contains(detectorIdRunning));
+            assertTrue(result4.contains(detectorIdDisabled1));
+            assertTrue(result4.contains(detectorIdDisabled2));
         } finally {
-            if (detectorId != null) {
-                deleteDetector(detectorId);
+            if (detectorIdRunning != null) {
+                stopDetector(detectorIdRunning);
+                Thread.sleep(5000);
+                deleteDetector(detectorIdRunning);
+            }
+            if (detectorIdDisabled1 != null) {
+                deleteDetector(detectorIdDisabled1);
+            }
+            if (detectorIdDisabled2 != null) {
+                deleteDetector(detectorIdDisabled2);
             }
         }
 

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -191,6 +191,28 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
             assertTrue(result4.contains(detectorIdRunning));
             assertTrue(result4.contains(detectorIdDisabled1));
             assertTrue(result4.contains(detectorIdDisabled2));
+
+            String agentInput5 = "{\"parameters\":{\"running\": \"true\", \"failed\": \"true\"}}";
+            String result5 = executeAgent(agentId, agentInput5);
+            assertTrue(result5.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+            assertTrue(result5.contains(detectorIdRunning));
+
+            String agentInput6 = "{\"parameters\":{\"running\": \"true\", \"failed\": \"false\"}}";
+            String result6 = executeAgent(agentId, agentInput6);
+            assertTrue(result6.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+            assertTrue(result6.contains(detectorIdRunning));
+
+            String agentInput7 = "{\"parameters\":{\"running\": \"false\", \"failed\": \"true\"}}";
+            String result7 = executeAgent(agentId, agentInput7);
+            assertTrue(result7.contains(String.format("TotalAnomalyDetectors=%d", 2)));
+            assertTrue(result7.contains(detectorIdDisabled1));
+            assertTrue(result7.contains(detectorIdDisabled2));
+
+            String agentInput8 = "{\"parameters\":{\"running\": \"false\", \"failed\": \"false\"}}";
+            String result8 = executeAgent(agentId, agentInput8);
+            assertTrue(result8.contains(String.format("TotalAnomalyDetectors=%d", 2)));
+            assertTrue(result8.contains(detectorIdDisabled1));
+            assertTrue(result8.contains(detectorIdDisabled2));
         } finally {
             if (detectorIdRunning != null) {
                 stopDetector(detectorIdRunning);

--- a/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
+++ b/src/test/java/org/opensearch/integTest/SearchAnomalyDetectorsToolIT.java
@@ -156,6 +156,31 @@ public class SearchAnomalyDetectorsToolIT extends BaseAgentToolsIT {
 
     @SneakyThrows
     @Order(6)
+    public void testSearchAnomalyDetectorsToolInFlowAgent_runningParam() {
+        String detectorId = "";
+        try {
+            setupTestDetectionIndex("test-index");
+            detectorId = ingestSampleDetector(detectorName, "test-index");
+            String agentId = createAgent(registerAgentRequestBody);
+            String agentInput = "{\"parameters\":{\"running\": \"true\"}}";
+            String result = executeAgent(agentId, agentInput);
+            assertEquals("AnomalyDetectors=[]TotalAnomalyDetectors=0", result);
+
+            String agentInput2 = "{\"parameters\":{\"running\": \"false\"}}";
+            String result2 = executeAgent(agentId, agentInput2);
+            assertTrue(result2.contains(String.format("id=%s", detectorId)));
+            assertTrue(result2.contains(String.format("name=%s", detectorName)));
+            assertTrue(result2.contains(String.format("TotalAnomalyDetectors=%d", 1)));
+        } finally {
+            if (detectorId != null) {
+                deleteDetector(detectorId);
+            }
+        }
+
+    }
+
+    @SneakyThrows
+    @Order(7)
     public void testSearchAnomalyDetectorsToolInFlowAgent_complexParams() {
         String detectorId = null;
         String detectorIdFoo = null;


### PR DESCRIPTION
### Description

This PR fixes two issues related to fetching and filtering detector state with the `SearchAnomalyDetectorsTool`.

#### `NamedWriteableRegistry` error
This fix coincides with https://github.com/opensearch-project/anomaly-detection/pull/1164 - see there for more details on the original issue.

This change injects the `NamedWriteableRegistry` to the AD-related tools, in order to construct the AD node client with its updated constructor params that now requires a `NamedWriteableRegistry`. At a high level, this is used in the node client for being able to successfully serialize/deserialize the `GetAnomalyDetectorResponse` used when fetching detector profiles, when the `SearchAnomalyDetectorsTool` is invoked where any state-related param is passed down - e.g., `running`/`failed`.


#### Detectors filtering bug
There is an issue (uncovered after the above fix was made causing the tests to fail) of detectors with mismatching states not being filtered out. The root cause was that the profile detector transport action response does not include the detector ID by default in the `anomalyDetector` field, hence it was always `null` and nothing was removed from the hits map. This changes that by using the detector name as the key in the hits map, which is returned by default.


#### Miscellaneous
- Removes `disabled` as a parameter. This caused LLM confusion, since a question like "how many stopped detectors do i have?" could lead to setting the parameters as `"disabled": "true"`, or `"running": "false"`. This simplifies that by only having one knob to turn instead of two. Additionally, this changes simplifies the filtering logic and the matrix combination of values shrink.
- Other filtering logic cleanup
- Adds integration tests to test out the detector state params and enforces filtering works as expected
- Cleans up existing integration tests to handle individual-test-failures more cleanly and less error logs when running the tests
- Cleans up existing unit tests
- Minor cleanup to search AD results ITs to handle various flakiness


The overall impact of these changes is that detector-state-related questions passed to an agent provisioned with the `SearchAnomalyDetectorsTool` now works as expected. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
