### PR TITLE
remove logic about replace quota for finetuning model

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -525,7 +525,7 @@ public class PPLTool implements Tool {
                 throw new IllegalArgumentException("The returned PPL: " + llmOutput + " has wrong format");
             }
         }
-        if (!this.pplModelType.equals(PPLModelType.FINETUNE)) {
+        if (this.pplModelType == PPLModelType.FINETUNE) {
             ppl = ppl.replace("`", "");
         }
         ppl = ppl.replaceAll("\\bSPAN\\(", "span(");

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -494,7 +494,6 @@ public class PPLTool implements Tool {
 
         if (matcher.find()) {
             ppl = matcher.group(1).replaceAll("[\\r\\n]", "").replaceAll("ISNOTNULL", "isnotnull").trim();
-            ppl = ppl.replace("`", "");
         } else { // logic for only ppl returned
             int sourceIndex = llmOutput.indexOf("source=");
             int describeIndex = llmOutput.indexOf("describe ");
@@ -525,6 +524,9 @@ public class PPLTool implements Tool {
             } else {
                 throw new IllegalArgumentException("The returned PPL: " + llmOutput + " has wrong format");
             }
+        }
+        if (!this.pplModelType.equals(PPLModelType.FINETUNE)) {
+            ppl = ppl.replace("`", "");
         }
         ppl = ppl.replaceAll("\\bSPAN\\(", "span(");
         if (this.head > 0) {

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -525,7 +525,7 @@ public class PPLTool implements Tool {
                 throw new IllegalArgumentException("The returned PPL: " + llmOutput + " has wrong format");
             }
         }
-        if (this.pplModelType == PPLModelType.FINETUNE) {
+        if (this.pplModelType != PPLModelType.FINETUNE) {
             ppl = ppl.replace("`", "");
         }
         ppl = ppl.replaceAll("\\bSPAN\\(", "span(");

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -494,6 +494,7 @@ public class PPLTool implements Tool {
 
         if (matcher.find()) {
             ppl = matcher.group(1).replaceAll("[\\r\\n]", "").replaceAll("ISNOTNULL", "isnotnull").trim();
+            ppl = ppl.replace("`", "");
         } else { // logic for only ppl returned
             int sourceIndex = llmOutput.indexOf("source=");
             int describeIndex = llmOutput.indexOf("describe ");
@@ -525,7 +526,6 @@ public class PPLTool implements Tool {
                 throw new IllegalArgumentException("The returned PPL: " + llmOutput + " has wrong format");
             }
         }
-        ppl = ppl.replace("`", "");
         ppl = ppl.replaceAll("\\bSPAN\\(", "span(");
         if (this.head > 0) {
             String[] lists = llmOutput.split("\\|");


### PR DESCRIPTION
### Description
remove logic about replace quota for finetuning model. The quota in finetune is special to solve some corner cases where the field name contains very special symbols like "$", "%", "@" 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
