### PR TITLE
Change AD jar name for 2.14 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ task addJarsToClasspath(type: Copy) {
     into("$buildDir/classes")
 
     from(fileTree(dir: adJarDirectory)) {
-        include "opensearch-time-series-analytics-${opensearch_build}.jar"
+        include "opensearch-anomaly-detection-${opensearch_build}.jar"
     }
     into("$buildDir/classes")
 }
@@ -124,7 +124,7 @@ dependencies {
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     implementation fileTree(dir: jsJarDirectory, include: ["opensearch-job-scheduler-${opensearch_build}.jar"])
-    implementation fileTree(dir: adJarDirectory, include: ["opensearch-time-series-analytics-${opensearch_build}.jar"])
+    implementation fileTree(dir: adJarDirectory, include: ["opensearch-anomaly-detection-${opensearch_build}.jar"])
     implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${opensearch_build}.jar", "ppl-${opensearch_build}.jar", "protocol-${opensearch_build}.jar"])
     compileOnly "org.opensearch:common-utils:${opensearch_build}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"

--- a/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchAnomalyDetectorsToolTests.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.ad.model.AnomalyDetector;
+import org.opensearch.ad.model.IntervalTimeConfiguration;
 import org.opensearch.ad.transport.GetAnomalyDetectorAction;
 import org.opensearch.ad.transport.GetAnomalyDetectorResponse;
 import org.opensearch.ad.transport.SearchAnomalyDetectorAction;
@@ -45,7 +46,6 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.search.SearchHit;
-import org.opensearch.timeseries.model.IntervalTimeConfiguration;
 
 public class SearchAnomalyDetectorsToolTests {
     @Mock
@@ -84,7 +84,6 @@ public class SearchAnomalyDetectorsToolTests {
             1,
             Instant.now(),
             Collections.emptyList(),
-            null,
             null,
             null
         );
@@ -126,7 +125,7 @@ public class SearchAnomalyDetectorsToolTests {
         content.field("last_update_time", testDetector.getLastUpdateTime().toEpochMilli());
         content.endObject();
         SearchHit[] hits = new SearchHit[1];
-        hits[0] = new SearchHit(0, testDetector.getId(), null, null).sourceRef(BytesReference.bytes(content));
+        hits[0] = new SearchHit(0, testDetector.getDetectorId(), null, null).sourceRef(BytesReference.bytes(content));
         SearchResponse getDetectorsResponse = TestHelpers.generateSearchResponse(hits);
         String expectedResponseStr = getExpectedResponseString(testDetector);
 
@@ -461,7 +460,7 @@ public class SearchAnomalyDetectorsToolTests {
         return String
             .format(
                 "AnomalyDetectors=[{id=%s,name=%s,type=%s,description=%s,index=%s,lastUpdateTime=%d}]TotalAnomalyDetectors=%d",
-                testDetector.getId(),
+                testDetector.getDetectorId(),
                 testDetector.getName(),
                 testDetector.getDetectorType(),
                 testDetector.getDescription(),


### PR DESCRIPTION
### Description

Changes the JAR filename extracted from the Anomaly Detection zip file to match the `opensearch-anomaly-detection` name in 2.14 release branch.

Partial reversion of changes in https://github.com/opensearch-project/skills/pull/290/files
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
