### PR TITLE
Deal endpoint failure problem

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -223,6 +223,10 @@ public class PPLTool implements Tool {
                     ModelTensor modelTensor = modelTensors.getMlModelTensors().get(0);
                     Map<String, String> dataAsMap = (Map<String, String>) modelTensor.getDataAsMap();
                     String ppl = parseOutput(dataAsMap.get("response"), indexName);
+                    if (ppl == null){
+                        listener.onFailure(new IllegalArgumentException("Endpoint fails to inference"));
+                        return;
+                    }
                     if (!this.execute) {
                         Map<String, String> ret = ImmutableMap.of("ppl", ppl);
                         listener.onResponse((T) AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(ret)));

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -222,8 +222,8 @@ public class PPLTool implements Tool {
                     ModelTensors modelTensors = modelTensorOutput.getMlModelOutputs().get(0);
                     ModelTensor modelTensor = modelTensors.getMlModelTensors().get(0);
                     Map<String, String> dataAsMap = (Map<String, String>) modelTensor.getDataAsMap();
-                    if (!dataAsMap.containsKey("response")){
-                        listener.onFailure(new IllegalArgumentException("Remote endpoint fails to inference"));
+                    if (dataAsMap.get("response") == null){
+                        listener.onFailure(new IllegalArgumentException("Remote endpoint fails to inference."));
                         return;
                     }
                     String ppl = parseOutput(dataAsMap.get("response"), indexName);

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -222,7 +222,7 @@ public class PPLTool implements Tool {
                     ModelTensors modelTensors = modelTensorOutput.getMlModelOutputs().get(0);
                     ModelTensor modelTensor = modelTensors.getMlModelTensors().get(0);
                     Map<String, String> dataAsMap = (Map<String, String>) modelTensor.getDataAsMap();
-                    if (dataAsMap.get("response") == null){
+                    if (dataAsMap.get("response") == null) {
                         listener.onFailure(new IllegalArgumentException("Remote endpoint fails to inference."));
                         return;
                     }

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -223,7 +223,7 @@ public class PPLTool implements Tool {
                     ModelTensor modelTensor = modelTensors.getMlModelTensors().get(0);
                     Map<String, String> dataAsMap = (Map<String, String>) modelTensor.getDataAsMap();
                     if (dataAsMap.get("response") == null) {
-                        listener.onFailure(new IllegalArgumentException("Remote endpoint fails to inference."));
+                        listener.onFailure(new IllegalStateException("Remote endpoint fails to inference."));
                         return;
                     }
                     String ppl = parseOutput(dataAsMap.get("response"), indexName);

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -222,11 +222,11 @@ public class PPLTool implements Tool {
                     ModelTensors modelTensors = modelTensorOutput.getMlModelOutputs().get(0);
                     ModelTensor modelTensor = modelTensors.getMlModelTensors().get(0);
                     Map<String, String> dataAsMap = (Map<String, String>) modelTensor.getDataAsMap();
-                    String ppl = parseOutput(dataAsMap.get("response"), indexName);
-                    if (ppl == null){
-                        listener.onFailure(new IllegalArgumentException("Endpoint fails to inference"));
+                    if (!dataAsMap.containsKey("response")){
+                        listener.onFailure(new IllegalArgumentException("Remote endpoint fails to inference"));
                         return;
                     }
+                    String ppl = parseOutput(dataAsMap.get("response"), indexName);
                     if (!this.execute) {
                         Map<String, String> ret = ImmutableMap.of("ppl", ppl);
                         listener.onResponse((T) AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(ret)));

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -275,15 +275,12 @@ public class PPLToolTests {
         initMLTensors();
 
         Exception exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
-                    assertEquals(pplResult, "ppl result");
-                }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+            IllegalArgumentException.class,
+            () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+                assertEquals(pplResult, "ppl result");
+            }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
         );
-        assertEquals(
-                "Remote endpoint fails to inference.",
-                exception.getMessage()
-        );
+        assertEquals("Remote endpoint fails to inference.", exception.getMessage());
     }
 
     @Test
@@ -296,15 +293,12 @@ public class PPLToolTests {
         initMLTensors();
 
         Exception exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
-                    assertEquals(pplResult, "ppl result");
-                }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+            IllegalArgumentException.class,
+            () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+                assertEquals(pplResult, "ppl result");
+            }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
         );
-        assertEquals(
-                "Remote endpoint fails to inference.",
-                exception.getMessage()
-        );
+        assertEquals("Remote endpoint fails to inference.", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -275,10 +275,10 @@ public class PPLToolTests {
         initMLTensors();
 
         Exception exception = assertThrows(
-            IllegalArgumentException.class,
+            IllegalStateException.class,
             () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
                 assertEquals(pplResult, "ppl result");
-            }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+            }, e -> { throw new IllegalStateException(e.getMessage()); }))
         );
         assertEquals("Remote endpoint fails to inference.", exception.getMessage());
     }
@@ -293,10 +293,10 @@ public class PPLToolTests {
         initMLTensors();
 
         Exception exception = assertThrows(
-            IllegalArgumentException.class,
+            IllegalStateException.class,
             () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
                 assertEquals(pplResult, "ppl result");
-            }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+            }, e -> { throw new IllegalStateException(e.getMessage()); }))
         );
         assertEquals("Remote endpoint fails to inference.", exception.getMessage());
     }

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -266,6 +266,48 @@ public class PPLToolTests {
     }
 
     @Test
+    public void testTool_withWrongEndpointInference() {
+        PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
+        assertEquals(PPLTool.TYPE, tool.getName());
+
+        pplReturns = Collections.singletonMap("code", "424");
+        modelTensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, pplReturns);
+        initMLTensors();
+
+        Exception exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+                    assertEquals(pplResult, "ppl result");
+                }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+        );
+        assertEquals(
+                "Remote endpoint fails to inference.",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    public void testTool_withWrongEndpointInferenceWithNullResponse() {
+        PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
+        assertEquals(PPLTool.TYPE, tool.getName());
+
+        pplReturns = Collections.singletonMap("response", null);
+        modelTensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, pplReturns);
+        initMLTensors();
+
+        Exception exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+                    assertEquals(pplResult, "ppl result");
+                }, e -> { throw new IllegalArgumentException(e.getMessage()); }))
+        );
+        assertEquals(
+                "Remote endpoint fails to inference.",
+                exception.getMessage()
+        );
+    }
+
+    @Test
     public void testTool_withDescribeStartPPL() {
         PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
         assertEquals(PPLTool.TYPE, tool.getName());


### PR DESCRIPTION
### Description
When sagemaker endpoint inference fails, it will return {"code":424,"message":"Batch inference failed","properties":{},"content":{"keys":[],"values":[]},"cancelled":false}
Which will inside model tensor dataAsMap. So we need to catch this NPE.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
