### PR TITLE
fix compilation error and change gradle version to compatible with jdk21

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,4 +4,4 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c

--- a/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
@@ -81,7 +81,7 @@ public class SearchMonitorsToolTests {
             new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), null),
             Instant.now(),
             Instant.now(),
-            Monitor.MonitorType.QUERY_LEVEL_MONITOR,
+            Monitor.MonitorType.QUERY_LEVEL_MONITOR.getValue(),
             new User("test-user", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
             0,
             Collections.emptyList(),


### PR DESCRIPTION
### Description
fix compilation error and change gradle version to compatible with jdk21
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
