### PR TITLE
Add LogPatternTool

### DIFF
--- a/src/main/java/org/opensearch/agent/ToolPlugin.java
+++ b/src/main/java/org/opensearch/agent/ToolPlugin.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 
 import org.opensearch.agent.tools.CreateAlertTool;
 import org.opensearch.agent.tools.CreateAnomalyDetectorTool;
+import org.opensearch.agent.tools.LogPatternTool;
 import org.opensearch.agent.tools.NeuralSparseSearchTool;
 import org.opensearch.agent.tools.PPLTool;
 import org.opensearch.agent.tools.RAGTool;
@@ -71,6 +72,7 @@ public class ToolPlugin extends Plugin implements MLCommonsExtension {
         SearchMonitorsTool.Factory.getInstance().init(client);
         CreateAlertTool.Factory.getInstance().init(client);
         CreateAnomalyDetectorTool.Factory.getInstance().init(client);
+        LogPatternTool.Factory.getInstance().init(client, xContentRegistry);
         return Collections.emptyList();
     }
 
@@ -87,7 +89,8 @@ public class ToolPlugin extends Plugin implements MLCommonsExtension {
                 SearchAnomalyResultsTool.Factory.getInstance(),
                 SearchMonitorsTool.Factory.getInstance(),
                 CreateAlertTool.Factory.getInstance(),
-                CreateAnomalyDetectorTool.Factory.getInstance()
+                CreateAnomalyDetectorTool.Factory.getInstance(),
+                LogPatternTool.Factory.getInstance()
             );
     }
 

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -68,7 +68,7 @@ public abstract class AbstractRetrieverTool implements Tool {
 
     protected abstract String getQueryBody(String queryText);
 
-    protected static Map<String, Object> processResponse(SearchHit hit) {
+    private static Map<String, Object> processResponse(SearchHit hit) {
         Map<String, Object> docContent = new HashMap<>();
         docContent.put("_index", hit.getIndex());
         docContent.put("_id", hit.getId());

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -89,8 +89,7 @@ public abstract class AbstractRetrieverTool implements Tool {
         searchSourceBuilder.parseXContent(queryParser);
         searchSourceBuilder.fetchSource(sourceFields, null);
         searchSourceBuilder.size(docSize);
-        SearchRequest searchRequest = new SearchRequest().source(searchSourceBuilder).indices(index);
-        return searchRequest;
+        return new SearchRequest().source(searchSourceBuilder).indices(parameters.getOrDefault(INDEX_FIELD, index));
     }
 
     @Override

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -68,7 +68,7 @@ public abstract class AbstractRetrieverTool implements Tool {
 
     protected abstract String getQueryBody(String queryText);
 
-    private static Map<String, Object> processResponse(SearchHit hit) {
+    protected static Map<String, Object> processResponse(SearchHit hit) {
         Map<String, Object> docContent = new HashMap<>();
         docContent.put("_index", hit.getIndex());
         docContent.put("_id", hit.getId());
@@ -77,7 +77,7 @@ public abstract class AbstractRetrieverTool implements Tool {
         return docContent;
     }
 
-    private <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
+    protected <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
         String question = parameters.get(INPUT_FIELD);
         if (StringUtils.isBlank(question)) {
             throw new IllegalArgumentException("[" + INPUT_FIELD + "] is null or empty, can not process it.");

--- a/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
+++ b/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools;
+
+import static org.opensearch.ml.common.utils.StringUtils.gson;
+
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.spi.tools.ToolAnnotation;
+import org.opensearch.search.SearchHit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * This tool supports generating log patterns on the input dsl and index. It's implemented by
+ * several steps:
+ * 1. Retrival [[${DOC_SIZE_FIELD}]] logs from index
+ * 2. Extract patterns for each retrieved log
+ *  2.1 Find Pattern Field: If users provide parameter [[${PATTERN_FIELD}]], use it as the pattern
+ *      field; Otherwise, find the string field with the longest length on the first log.
+ *  2.2 Extract Pattern: If users provide parameter [[${PATTERN}]], compile it as a pattern;
+ *      Otherwise, use [[${DEFAULT_IGNORED_CHARS}]]. It will remove all chars matching the pattern.
+ * 3. Group logs by their extracted patterns.
+ * 4. Find top N patterns with the largest sample log size.
+ * 5. For each found top N patterns, return [[${SAMPLE_LOG_SIZE}]] sample logs.
+ */
+@Log4j2
+@Getter
+@Setter
+@ToolAnnotation(LogPatternTool.TYPE)
+public class LogPatternTool extends AbstractRetrieverTool {
+    public static final String TYPE = "LogPatternTool";
+
+    public static String DEFAULT_DESCRIPTION = "Log Pattern Tool";
+    public static final String TOP_N_PATTERN = "top_n_pattern";
+    public static final String SAMPLE_LOG_SIZE = "sample_log_size";
+    public static final String DSL_FIELD = "dsl";
+    public static final String PATTERN_FIELD = "pattern_field";
+    public static final String PATTERN = "pattern";
+    public static final int LOG_PATTERN_DEFAULT_DOC_SIZE = 1000;
+    public static final int DEFAULT_TOP_N_PATTERN = 3;
+    public static final int DEFAULT_SAMPLE_LOG_SIZE = 20;
+    private static final ImmutableSet<Character> DEFAULT_IGNORED_CHARS = ImmutableSet
+        .copyOf("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".chars().mapToObj(c -> (char) c).toArray(Character[]::new));
+
+    private String name = TYPE;
+    private int topNPattern;
+    private int sampleLogSize;
+    @EqualsAndHashCode.Exclude
+    private Pattern pattern;
+
+    @Builder
+    public LogPatternTool(
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        int docSize,
+        int topNPattern,
+        int sampleLogSize,
+        String patternStr
+    ) {
+        super(client, xContentRegistry, null, null, docSize);
+        this.topNPattern = topNPattern;
+        this.sampleLogSize = sampleLogSize;
+        if (pattern != null)
+            this.pattern = Pattern.compile(patternStr);
+    }
+
+    @Override
+    protected String getQueryBody(String queryText) {
+        return queryText;
+    }
+
+    @Override
+    public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
+        super.index = parameters.get(INDEX_FIELD);
+        if (parameters.containsKey(DOC_SIZE_FIELD))
+            super.docSize = Integer.parseInt(parameters.get(DOC_SIZE_FIELD));
+        if (parameters.containsKey(TOP_N_PATTERN))
+            topNPattern = Integer.parseInt(parameters.get(TOP_N_PATTERN));
+        if (parameters.containsKey(SAMPLE_LOG_SIZE))
+            sampleLogSize = Integer.parseInt(parameters.get(SAMPLE_LOG_SIZE));
+        if (parameters.containsKey(PATTERN))
+            this.pattern = Pattern.compile((parameters.get(PATTERN)));
+
+        SearchRequest searchRequest;
+        try {
+            searchRequest = buildSearchRequest(parameters);
+        } catch (Exception e) {
+            log.error("Failed to build search request.", e);
+            listener.onFailure(e);
+            return;
+        }
+
+        ActionListener actionListener = ActionListener.<SearchResponse>wrap(r -> {
+            SearchHit[] hits = r.getHits().getHits();
+
+            if (hits != null && hits.length > 0) {
+                String patternField = parameters.containsKey(PATTERN_FIELD)
+                    ? parameters.get(PATTERN_FIELD)
+                    : findLongestField(hits[0].getSourceAsMap());
+                if (patternField == null) {
+                    listener.onResponse((T) "Pattern field is not set and this index doesn't contain any string field");
+                }
+                Map<String, List<Map<String, Object>>> patternGroups = new HashMap<>();
+                for (SearchHit hit : hits) {
+                    Map<String, Object> source = hit.getSourceAsMap();
+                    String pattern = extractPattern((String) source.getOrDefault(patternField, ""), this.pattern);
+                    List<Map<String, Object>> group = patternGroups.computeIfAbsent(pattern, k -> new ArrayList<>());
+                    group.add(source);
+                }
+                List<Map<String, Object>> sortedEntries = patternGroups
+                    .entrySet()
+                    .stream()
+                    .sorted(Comparator.comparingInt(entry -> -entry.getValue().size()))
+                    .limit(topNPattern)
+                    .map(
+                        entry -> Map
+                            .of(
+                                "total count",
+                                entry.getValue().size(),
+                                "pattern",
+                                entry.getKey(),
+                                "sample logs",
+                                entry.getValue().subList(0, Math.min(entry.getValue().size(), sampleLogSize))
+                            )
+                    )
+                    .toList();
+
+                listener
+                    .onResponse((T) AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> gson.toJson(sortedEntries)));
+            } else {
+                listener.onResponse((T) "Can not get any match from search result.");
+            }
+        }, e -> {
+            log.error("Failed to search index.", e);
+            listener.onFailure(e);
+        });
+        client.search(searchRequest, actionListener);
+    }
+
+    @VisibleForTesting
+    public static String extractPattern(String rawString, Pattern pattern) {
+        if (pattern != null)
+            return pattern.matcher(rawString).replaceAll("");
+        char[] chars = rawString.toCharArray();
+        int pos = 0;
+        for (int i = 0; i < chars.length; i++) {
+            if (!DEFAULT_IGNORED_CHARS.contains(chars[i])) {
+                chars[pos++] = chars[i];
+            }
+        }
+        return new String(chars, 0, pos);
+    }
+
+    @VisibleForTesting
+    public static String findLongestField(Map<String, Object> sampleLogSource) {
+        String longestField = null;
+        int maxLength = 0;
+
+        for (Map.Entry<String, Object> entry : sampleLogSource.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String) { // 确保值是字符串类型
+                String stringValue = (String) value;
+                int length = stringValue.length();
+                if (length > maxLength) {
+                    maxLength = length;
+                    longestField = entry.getKey();
+                }
+            }
+        }
+        return longestField;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static class Factory extends AbstractRetrieverTool.Factory<LogPatternTool> {
+        private static LogPatternTool.Factory INSTANCE;
+
+        public static LogPatternTool.Factory getInstance() {
+            if (INSTANCE != null) {
+                return INSTANCE;
+            }
+            synchronized (LogPatternTool.class) {
+                if (INSTANCE != null) {
+                    return INSTANCE;
+                }
+                INSTANCE = new LogPatternTool.Factory();
+                return INSTANCE;
+            }
+        }
+
+        @Override
+        public LogPatternTool create(Map<String, Object> params) {
+            int docSize = params.containsKey(DOC_SIZE_FIELD)
+                ? Integer.parseInt((String) params.get(DOC_SIZE_FIELD))
+                : LOG_PATTERN_DEFAULT_DOC_SIZE;
+            int topNPattern = params.containsKey(TOP_N_PATTERN)
+                ? Integer.parseInt((String) params.get(TOP_N_PATTERN))
+                : DEFAULT_TOP_N_PATTERN;
+            int sampleLogSize = params.containsKey(SAMPLE_LOG_SIZE)
+                ? Integer.parseInt((String) params.get(SAMPLE_LOG_SIZE))
+                : DEFAULT_SAMPLE_LOG_SIZE;
+            String patternStr = params.containsKey(PATTERN) ? (String) params.get(PATTERN) : null;
+            return LogPatternTool
+                .builder()
+                .client(client)
+                .xContentRegistry(xContentRegistry)
+                .docSize(docSize)
+                .topNPattern(topNPattern)
+                .sampleLogSize(sampleLogSize)
+                .patternStr(patternStr)
+                .build();
+        }
+
+        @Override
+        public String getDefaultType() {
+            return TYPE;
+        }
+
+        @Override
+        public String getDefaultVersion() {
+            return null;
+        }
+
+        @Override
+        public String getDefaultDescription() {
+            return DEFAULT_DESCRIPTION;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
+++ b/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
@@ -97,8 +97,6 @@ public class LogPatternTool extends AbstractRetrieverTool {
 
     @Override
     public <T> void run(Map<String, String> parameters, ActionListener<T> listener) {
-        // LogPatternTool needs to pass index and input as parameter in runtime. See [[${validate}]]
-        super.index = parameters.get(INDEX_FIELD);
         int topNPattern = parameters.containsKey(TOP_N_PATTERN) ? getPositiveInteger(parameters, TOP_N_PATTERN) : this.topNPattern;
         int sampleLogSize = parameters.containsKey(SAMPLE_LOG_SIZE) ? getPositiveInteger(parameters, SAMPLE_LOG_SIZE) : this.sampleLogSize;
         Pattern pattern = parameters.containsKey(PATTERN) ? Pattern.compile(parameters.get(PATTERN)) : this.pattern;
@@ -214,6 +212,7 @@ public class LogPatternTool extends AbstractRetrieverTool {
 
     @Override
     public boolean validate(Map<String, String> parameters) {
+        // LogPatternTool needs to pass index and input as parameter in runtime.
         return super.validate(parameters) && parameters.containsKey(INDEX_FIELD) && !StringUtils.isBlank(parameters.get(INDEX_FIELD));
     }
 

--- a/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
+++ b/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
@@ -159,6 +159,14 @@ public class LogPatternTool extends AbstractRetrieverTool {
         client.search(searchRequest, actionListener);
     }
 
+    /**
+     * Extract a pattern from the value of a field by removing chars in the pattern. This function
+     * imitates the same logic of Observability log pattern feature here:
+     * <a href="https://github.com/opensearch-project/sql/blob/4303a2ab755d53903094dd94a5100572677a27a1/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java#L53">parseValue</a>
+     * @param rawString string value of the field to generate a pattern
+     * @param pattern @Nullable the specified pattern to remove, use DEFAULT_IGNORED_CHARS if null
+     * @return the generated pattern value
+     */
     @VisibleForTesting
     static String extractPattern(String rawString, Pattern pattern) {
         if (pattern != null)
@@ -173,6 +181,13 @@ public class LogPatternTool extends AbstractRetrieverTool {
         return new String(chars, 0, pos);
     }
 
+    /**
+     * Find the longest field in the sample log source. This function imitates the same logic of
+     * Observability log pattern feature here:
+     * <a href="https://github.com/opensearch-project/dashboards-observability/blob/279463ad0c8e00780bf57f85e6d2bf30e8c7c93d/public/components/event_analytics/hooks/use_fetch_patterns.ts#L137C2-L164C6">setDefaultPatternsField</a>
+     * @param sampleLogSource sample log source map
+     * @return the longest field name
+     */
     @VisibleForTesting
     static String findLongestField(Map<String, Object> sampleLogSource) {
         String longestField = null;

--- a/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
+++ b/src/main/java/org/opensearch/agent/tools/LogPatternTool.java
@@ -55,7 +55,7 @@ import lombok.extern.log4j.Log4j2;
 public class LogPatternTool extends AbstractRetrieverTool {
     public static final String TYPE = "LogPatternTool";
 
-    public static String DEFAULT_DESCRIPTION = "Log Pattern Tool";
+    public static final String DEFAULT_DESCRIPTION = "Log Pattern Tool";
     public static final String TOP_N_PATTERN = "top_n_pattern";
     public static final String SAMPLE_LOG_SIZE = "sample_log_size";
     public static final String PATTERN_FIELD = "pattern_field";
@@ -119,6 +119,7 @@ public class LogPatternTool extends AbstractRetrieverTool {
                     : findLongestField(hits[0].getSourceAsMap());
                 if (patternField == null) {
                     listener.onResponse((T) "Pattern field is not set and this index doesn't contain any string field");
+                    return;
                 }
                 Map<String, List<Map<String, Object>>> patternGroups = new HashMap<>();
                 for (SearchHit hit : hits) {
@@ -235,7 +236,7 @@ public class LogPatternTool extends AbstractRetrieverTool {
     }
 
     private static void checkPositive(int value, String paramName) {
-        if (value < 0) {
+        if (value <= 0) {
             throw new IllegalArgumentException(
                 LoggerMessageFormat.format("Invalid value {} for parameter {}, it should be positive", value, paramName)
             );

--- a/src/test/java/org/opensearch/agent/tools/LogPatternToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/LogPatternToolTests.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,5 +52,7 @@ public class LogPatternToolTests {
     @Test
     public void testExtractPattern() {
         assertEquals("././", LogPatternTool.extractPattern("123.abc/.AB/", null));
+        assertEquals("123.c/.AB/", LogPatternTool.extractPattern("123.abc/.AB/", Pattern.compile("ab")));
+        assertEquals(".abc/.AB/", LogPatternTool.extractPattern("123.abc/.AB/", Pattern.compile("[0-9]")));
     }
 }

--- a/src/test/java/org/opensearch/agent/tools/LogPatternToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/LogPatternToolTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import lombok.SneakyThrows;
+
+public class LogPatternToolTests {
+
+    public static final String TEST_QUERY_TEXT = "123fsd23134sdfouh";
+    private Map<String, Object> params = new HashMap<>();
+
+    @Before
+    public void setup() {}
+
+    @Test
+    @SneakyThrows
+    public void testCreateTool() {
+        LogPatternTool tool = LogPatternTool.Factory.getInstance().create(params);
+        assertEquals(LogPatternTool.LOG_PATTERN_DEFAULT_DOC_SIZE, (int) tool.docSize);
+        assertEquals(LogPatternTool.DEFAULT_TOP_N_PATTERN, tool.getTopNPattern());
+        assertEquals(LogPatternTool.DEFAULT_SAMPLE_LOG_SIZE, tool.getSampleLogSize());
+        assertNull(tool.getPattern());
+        assertEquals("LogPatternTool", tool.getType());
+        assertEquals("LogPatternTool", tool.getName());
+        assertEquals(LogPatternTool.DEFAULT_DESCRIPTION, LogPatternTool.Factory.getInstance().getDefaultDescription());
+    }
+
+    @Test
+    public void testGetQueryBody() {
+        LogPatternTool tool = LogPatternTool.Factory.getInstance().create(params);
+        assertEquals(TEST_QUERY_TEXT, tool.getQueryBody(TEST_QUERY_TEXT));
+    }
+
+    @Test
+    public void testFindLongestField() {
+        assertEquals("field2", LogPatternTool.findLongestField(Map.of("field1", "123", "field2", "1234", "filed3", 1234)));
+    }
+
+    @Test
+    public void testExtractPattern() {
+        assertEquals("././", LogPatternTool.extractPattern("123.abc/.AB/", null));
+    }
+}

--- a/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
@@ -88,6 +88,7 @@ public class SearchMonitorsToolTests {
             Collections.emptyList(),
             Collections.emptyMap(),
             new DataSources(),
+            false,
             ""
         );
     }


### PR DESCRIPTION
### Description
Add LogPatternTool to support generate log patterns based on an input `DSL`.

#### Background of log pattern 
Log pattern is a feature in Observability. It aims to find the common feature among retrieved logs.

The implementation of the log pattern feature in Observability includes 3 steps:

1. execute a PPL to retrieve the first log
2. set default pattern field, which is implemented in front-end. The default pattern field is found by scanning over the values of the first sample log. The field with the longest length of value will be the default pattern field. ([Code Ref](https://github.com/opensearch-project/dashboards-observability/blob/279463ad0c8e00780bf57f85e6d2bf30e8c7c93d/public/components/event_analytics/hooks/use_fetch_patterns.ts#L137C2-L164C6); For alert analysis, it seems meaningless to find pattern on the field with the longest length of value.)
3. execute a PPL to retrieve data and fill in log pattern table. Assuming field message is the pattern field, an example of such an PPL is:
    `source=opensearch_dashboards_sample_data_flights | where timestamp >= ’[2024-09-09 16](tel:2024090916):16:30.321000' and timestamp <= '2024-09-10 07:16:30.322000' | patterns Dest | stats count(), take(Dest, 1) by patterns_field` 
    By default, the operator pattern in PPL will generate a new field named pattern_field which will ignore characters conatined by [a-zA-Z\d] in the original value([Code Ref](https://github.com/opensearch-project/sql/blob/4303a2ab755d53903094dd94a5100572677a27a1/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java#L27); For alert analysis, it also seems less helpful to analysis on such pattern). 

However, if customers use `DSL` to retrieve logs, it doesn't support such feature. Thus we need this tool to achieve this goal.

#### Implementation of LogPatternTool
This tool supports generating log patterns on the input dsl and index. It's implemented by
several steps:
1. Retrival [[${DOC_SIZE_FIELD}]] logs from index
2. Extract patterns for each retrieved log
 2.1 Find Pattern Field: If users provide parameter [[${PATTERN_FIELD}]], use it as the pattern
     field; Otherwise, find the string field with the longest length on the first log.
 2.2 Extract Pattern: If users provide parameter [[${PATTERN}]], compile it as a pattern;
     Otherwise, use [[${DEFAULT_IGNORED_CHARS}]]. It will remove all chars matching the pattern.
3. Group logs by their extracted patterns.
4. Find top N patterns with the largest sample log size.
5. For each found top N patterns, return [[${SAMPLE_LOG_SIZE}]] sample logs.

#### Example
```
POST _plugins/_ml/agents/V4pYKJIBf_90oTl_gmnp/_execute
{
    "parameters": {
       "selected_tools": ["LogPatternTool"],
       "top_n_pattern": "3",
       "sample_log_size": "20",
       "doc_size": 100,
        "input":  """
{"query":{"bool":{"filter":[{"range":{"timestamp":{"from":"1727172421713||-1h","to":"1727172421713","include_lower":true,"include_upper":true,"boost":1}}},{"term":{"response":{"value":"200","boost":1}}}],"adjust_pure_negative":true,"boost":1}}}
        """
    }
}
```
![image](https://github.com/user-attachments/assets/d9ebe834-bdbe-4346-b850-6b0c4f8d7701)


### Related Issues


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
