### PR TITLE
ut fix: construct update in Monitor

### DIFF
--- a/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/SearchMonitorsToolTests.java
@@ -88,6 +88,7 @@ public class SearchMonitorsToolTests {
             Collections.emptyList(),
             Collections.emptyMap(),
             new DataSources(),
+            false,
             ""
         );
     }


### PR DESCRIPTION
### Description
`org.opensearch.commons.alerting.model.Monitor` add a new parameter in its constructor(https://github.com/opensearch-project/common-utils/commit/d7fd7b6b1963f82843fb1bda0bde71fd3618bd76), which cause test file compile failing. Fix it by adding default value.

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
