### PR TITLE
Fix CreateAnomalyDetectorTool doesn't support data streams and alias

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
@@ -186,13 +186,9 @@ public class CreateAnomalyDetectorTool implements Tool {
                 throw new IllegalArgumentException("No mapping found for the index: " + indexName);
             }
 
-            MappingMetadata mappingMetadata;
-            // when the index name is wildcard pattern, we fetch the mappings of the first index
-            if (indexName.contains("*")) {
-                mappingMetadata = mappings.get((String) mappings.keySet().toArray()[0]);
-            } else {
-                mappingMetadata = mappings.get(indexName);
-            }
+            // when the index name is wildcard pattern, data stream, or alias, we fetch the mappings of the first index
+            String firstIndexName = (String) mappings.keySet().toArray()[0];
+            MappingMetadata mappingMetadata = mappings.get(firstIndexName);
 
             Map<String, Object> mappingSource = (Map<String, Object>) mappingMetadata.getSourceAsMap().get("properties");
             if (Objects.isNull(mappingSource)) {
@@ -224,7 +220,7 @@ public class CreateAnomalyDetectorTool implements Tool {
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
             // construct the prompt
-            String prompt = constructPrompt(filteredMapping, indexName);
+            String prompt = constructPrompt(filteredMapping, firstIndexName);
             RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
                 .builder()
                 .parameters(Collections.singletonMap("prompt", prompt))
@@ -278,7 +274,7 @@ public class CreateAnomalyDetectorTool implements Tool {
                 Map<String, String> result = ImmutableMap
                     .of(
                         OUTPUT_KEY_INDEX,
-                        indexName,
+                        firstIndexName,
                         OUTPUT_KEY_CATEGORY_FIELD,
                         categoryField,
                         OUTPUT_KEY_AGGREGATION_FIELD,

--- a/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
@@ -186,7 +186,7 @@ public class CreateAnomalyDetectorTool implements Tool {
                 throw new IllegalArgumentException("No mapping found for the index: " + indexName);
             }
 
-            // when the index name is wildcard pattern, data stream, or alias, we fetch the mappings of the first index
+            // when the index name is a wildcard pattern, a data stream, or an alias, we fetch the mappings of the first index
             String firstIndexName = (String) mappings.keySet().toArray()[0];
             MappingMetadata mappingMetadata = mappings.get(firstIndexName);
 

--- a/src/test/java/org/opensearch/agent/tools/CreateAnomalyDetectorToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAnomalyDetectorToolTests.java
@@ -71,7 +71,7 @@ public class CreateAnomalyDetectorToolTests {
         "{\"index\":\"http_logs\",\"categoryField\":\"\",\"aggregationField\":\"response,responseLatency\",\"aggregationMethod\":\"count,avg\",\"dateFields\":\"date\"}";
 
     private String mockedResultForIndexPattern =
-        "{\"index\":\"http_logs*\",\"categoryField\":\"\",\"aggregationField\":\"response,responseLatency\",\"aggregationMethod\":\"count,avg\",\"dateFields\":\"date\"}";
+        "{\"index\":\"http_logs\",\"categoryField\":\"\",\"aggregationField\":\"response,responseLatency\",\"aggregationMethod\":\"count,avg\",\"dateFields\":\"date\"}";
 
     @Before
     public void setup() {


### PR DESCRIPTION
### Description

This PR fixes the bug of  CreateAnomalyDetectorTool doesn't support data streams and alias, when calling with a data stream or alias, that tool throws `null_pointer_exception` because the name of data stream or alias is not the key of the mapping, we should use a concrete index name to get the mapping.

### Related Issues
https://github.com/opensearch-project/skills/issues/337

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
