### PR TITLE
[Backport-279|43] fix(deps): update dependency net.bytebuddy:byte-buddy-agent to v1.15.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,8 +147,8 @@ dependencies {
     testImplementation group: 'org.json', name: 'json', version: '20240205'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
-    testImplementation("net.bytebuddy:byte-buddy:1.14.9")
-    testImplementation("net.bytebuddy:byte-buddy-agent:1.14.7")
+    testImplementation("net.bytebuddy:byte-buddy:1.15.4")
+    testImplementation("net.bytebuddy:byte-buddy-agent:1.15.4")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.10.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"


### PR DESCRIPTION
### Description
fix(deps): update dependency net.bytebuddy:byte-buddy-agent to v1.15.4
fix(deps): update dependency net.bytebuddy:byte-buddy to v1.15.4
### Related Issues
#279 
#43 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
