### PR TITLE
Support pass prompt to CreateAlertTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,12 +148,12 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.json', name: 'json', version: '20240303'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.13.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.14.2'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
     testImplementation("net.bytebuddy:byte-buddy:1.15.4")
     testImplementation("net.bytebuddy:byte-buddy-agent:1.15.4")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.2'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.13.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.14.2'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "com.cronutils:cron-utils:9.2.1"
     testImplementation "commons-validator:commons-validator:1.8.0"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ buildscript {
 plugins {
     id 'java-library'
     id 'com.diffplug.spotless' version '6.25.0'
-    id "io.freefair.lombok" version "8.10"
+    id "io.freefair.lombok" version "8.10.2"
     id "de.undercouch.download" version "5.6.0"
 }
 

--- a/src/main/java/org/opensearch/agent/tools/CreateAlertTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAlertTool.java
@@ -66,6 +66,8 @@ public class CreateAlertTool implements Tool {
     @Getter
     private final String modelId;
     @Getter
+    private final String modelType;
+    @Getter
     private final String toolPrompt;
 
     private static final String MODEL_ID = "model_id";
@@ -93,9 +95,9 @@ public class CreateAlertTool implements Tool {
     public CreateAlertTool(Client client, String modelId, String modelType, String prompt) {
         this.client = client;
         this.modelId = modelId;
-        modelType = String.valueOf(ModelType.from(modelType));
+        this.modelType = String.valueOf(ModelType.from(modelType));
         if (prompt.isEmpty()) {
-            if (!promptDict.containsKey(modelType)) {
+            if (!promptDict.containsKey(this.modelType)) {
                 throw new IllegalArgumentException(
                     LoggerMessageFormat
                         .format(
@@ -106,7 +108,7 @@ public class CreateAlertTool implements Tool {
                         )
                 );
             }
-            this.toolPrompt = promptDict.get(modelType);
+            this.toolPrompt = promptDict.get(this.modelType);
         } else {
             this.toolPrompt = prompt;
         }

--- a/src/main/java/org/opensearch/agent/tools/CreateAlertTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAlertTool.java
@@ -11,6 +11,7 @@ import static org.opensearch.ml.common.utils.StringUtils.isJson;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -72,9 +73,27 @@ public class CreateAlertTool implements Tool {
     private static final String DEFAULT_QUESTION = "Create an alert as your recommendation based on the context";
     private static final Map<String, String> promptDict = ToolHelper.loadDefaultPromptDictFromFile(CreateAlertTool.class, PROMPT_FILE_PATH);
 
+    public enum ModelType {
+        CLAUDE,
+        OPENAI;
+
+        public static ModelType from(String value) {
+            if (value.isEmpty()) {
+                return ModelType.CLAUDE;
+            }
+            try {
+                return ModelType.valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (Exception e) {
+                log.error("Wrong Model type, should be CLAUDE or OPENAI");
+                return ModelType.CLAUDE;
+            }
+        }
+    }
+
     public CreateAlertTool(Client client, String modelId, String modelType, String prompt) {
         this.client = client;
         this.modelId = modelId;
+        modelType = String.valueOf(ModelType.from(modelType));
         if (prompt.isEmpty()) {
             if (!promptDict.containsKey(modelType)) {
                 throw new IllegalArgumentException(

--- a/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
@@ -159,7 +159,9 @@ public class CreateAlertToolTests {
 
     @Test
     public void testTool_WithNonSupportedModelType() {
-        CreateAlertTool alertTool = CreateAlertTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"));
+        CreateAlertTool alertTool = CreateAlertTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"));
         assertEquals("CLAUDE", alertTool.getModelType());
     }
 

--- a/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
@@ -172,6 +172,22 @@ public class CreateAlertToolTests {
     }
 
     @Test
+    public void testToolWithCustomPrompt() {
+        CreateAlertTool tool = CreateAlertTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "prompt", "custom prompt"));
+        assertEquals(CreateAlertTool.TYPE, tool.getName());
+        assertEquals("modelId", tool.getModelId());
+        assertEquals("custom prompt", tool.getToolPrompt());
+
+        tool
+            .run(
+                ImmutableMap.of("indices", mockedIndexName),
+                ActionListener.<String>wrap(response -> assertEquals(jsonResponse, response), log::info)
+            );
+    }
+
+    @Test
     public void testTool() {
         // test json response
         initMLTensors(jsonResponse);

--- a/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
@@ -159,17 +159,13 @@ public class CreateAlertToolTests {
 
     @Test
     public void testTool_WithNonSupportedModelType() {
-        CreateAlertTool alertTool = CreateAlertTool.Factory
-            .getInstance()
-            .create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"));
+        CreateAlertTool alertTool = CreateAlertTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"));
         assertEquals("CLAUDE", alertTool.getModelType());
     }
 
     @Test
     public void testTool_WithEmptyModelType() {
-        CreateAlertTool alertTool = CreateAlertTool.Factory
-            .getInstance()
-            .create(ImmutableMap.of("model_id", "modelId", "model_type", ""));
+        CreateAlertTool alertTool = CreateAlertTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "model_type", ""));
         assertEquals("CLAUDE", alertTool.getModelType());
     }
 

--- a/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAlertToolTests.java
@@ -159,16 +159,18 @@ public class CreateAlertToolTests {
 
     @Test
     public void testTool_WithNonSupportedModelType() {
-        Exception exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> CreateAlertTool.Factory
-                .getInstance()
-                .create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"))
-        );
-        assertEquals(
-            "Failed to find the right prompt for modelType: non_supported_modelType, this tool supports prompts for these models: [CLAUDE,OPENAI]",
-            exception.getMessage()
-        );
+        CreateAlertTool alertTool = CreateAlertTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "model_type", "non_supported_modelType"));
+        assertEquals("CLAUDE", alertTool.getModelType());
+    }
+
+    @Test
+    public void testTool_WithEmptyModelType() {
+        CreateAlertTool alertTool = CreateAlertTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "model_type", ""));
+        assertEquals("CLAUDE", alertTool.getModelType());
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR enhance the CreateAlertTool with 2 features:
- support pass prompt as parameter to override the default prompt.
- use CLAUDE  as its default model type if model_type in parameters is empty or unsupported.

### Related Issues
Resolves https://github.com/opensearch-project/skills/issues/447

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
