### PR TITLE
CreateAnomalyDetectorTool supports empty model_type

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
@@ -431,8 +431,8 @@ public class CreateAnomalyDetectorTool implements Tool {
             String modelType = (String) map.getOrDefault("model_type", ModelType.CLAUDE.toString());
             if (modelType.isEmpty()) {
                 modelType = ModelType.CLAUDE.toString();
-            }
-            if (!ModelType.OPENAI.toString().equalsIgnoreCase(modelType) && !ModelType.CLAUDE.toString().equalsIgnoreCase(modelType)) {
+            } else if (!ModelType.OPENAI.toString().equalsIgnoreCase(modelType)
+                && !ModelType.CLAUDE.toString().equalsIgnoreCase(modelType)) {
                 throw new IllegalArgumentException("Unsupported model_type: " + modelType);
             }
             String prompt = (String) map.getOrDefault("prompt", "");

--- a/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
@@ -429,6 +429,9 @@ public class CreateAnomalyDetectorTool implements Tool {
                 throw new IllegalArgumentException("model_id cannot be empty.");
             }
             String modelType = (String) map.getOrDefault("model_type", ModelType.CLAUDE.toString());
+            if (modelType.isEmpty()) {
+                modelType = ModelType.CLAUDE.toString();
+            }
             if (!ModelType.OPENAI.toString().equalsIgnoreCase(modelType) && !ModelType.CLAUDE.toString().equalsIgnoreCase(modelType)) {
                 throw new IllegalArgumentException("Unsupported model_type: " + modelType);
             }

--- a/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
+++ b/src/main/java/org/opensearch/agent/tools/CreateAnomalyDetectorTool.java
@@ -429,6 +429,7 @@ public class CreateAnomalyDetectorTool implements Tool {
                 throw new IllegalArgumentException("model_id cannot be empty.");
             }
             String modelType = (String) map.getOrDefault("model_type", ModelType.CLAUDE.toString());
+            // if model type is empty, use the default value
             if (modelType.isEmpty()) {
                 modelType = ModelType.CLAUDE.toString();
             } else if (!ModelType.OPENAI.toString().equalsIgnoreCase(modelType)

--- a/src/test/java/org/opensearch/agent/tools/CreateAnomalyDetectorToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/CreateAnomalyDetectorToolTests.java
@@ -260,6 +260,22 @@ public class CreateAnomalyDetectorToolTests {
             );
     }
 
+    @Test
+    public void testToolWithEmptyModelType() {
+        CreateAnomalyDetectorTool tool = CreateAnomalyDetectorTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "model_type", ""));
+        assertEquals(CreateAnomalyDetectorTool.TYPE, tool.getName());
+        assertEquals("modelId", tool.getModelId());
+        assertEquals("CLAUDE", tool.getModelType().toString());
+
+        tool
+            .run(
+                ImmutableMap.of("index", mockedIndexName),
+                ActionListener.<String>wrap(response -> assertEquals(mockedResult, response), log::info)
+            );
+    }
+
     private void createMappings() {
         indexMappings = new HashMap<>();
         indexMappings


### PR DESCRIPTION
### Description
Same to the PPLTool, CreateAnomalyDetectorTool should also support empty model_type parameter, rather than throwing an `IllegalArgumentException`, we need to make the behavior consistent between the tools.

### Related Issues
No issue.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
