### PR TITLE
Fix: bump byte buddy version from 1.15.4 to 1.15.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,8 @@ dependencies {
     testImplementation group: 'org.json', name: 'json', version: '20240303'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.14.2'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
-    testImplementation("net.bytebuddy:byte-buddy:1.15.4")
-    testImplementation("net.bytebuddy:byte-buddy-agent:1.15.4")
+    testImplementation("net.bytebuddy:byte-buddy:1.15.10")
+    testImplementation("net.bytebuddy:byte-buddy-agent:1.15.10")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.2'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.14.2'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"


### PR DESCRIPTION
### Description
bump byte buddy version from 1.15.4 to 1.15.10

### Related Issues
Resolves module conflict introduced by this PR: https://github.com/opensearch-project/OpenSearch/pull/16655

```
* What went wrong:
Execution failed for task ':compileTestJava'.
> Could not resolve all dependencies for configuration ':testCompileClasspath'.
   > Conflict found for the following module:
       - net.bytebuddy:byte-buddy between versions 1.15.10 and 1.15.4
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
