### PR TITLE
Fix github ci linux build and RAG tool missing return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,50 +9,31 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    runs-on: ubuntu-latest
-    outputs:
-      ci-image-version-linux: ${{ steps.step-ci-image-version-linux.outputs.ci-image-version-linux }}
-    steps:
-      - name: Install crane
-        uses: iarekylew00t/crane-installer@v1
-        with:
-          crane-release: v0.15.2
-      - name: Checkout opensearch-build repository
-        uses: actions/checkout@v3
-        with:
-          repository: 'opensearch-project/opensearch-build'
-          ref: 'main'
-          path: 'opensearch-build'
-      - name: Get ci image version from opensearch-build repository scripts
-        id: step-ci-image-version-linux
-        run: |
-          crane version
-          CI_IMAGE_VERSION=`opensearch-build/docker/ci/get-ci-images.sh -p centos7 -u opensearch -t build | head -1`
-          echo $CI_IMAGE_VERSION
-          echo "ci-image-version-linux=$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT 
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+        product: opensearch
 
   build-linux:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
         java: [21]
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     name: Build and Test skills plugin on Linux
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -64,7 +45,7 @@ jobs:
                                ./gradlew publishToMavenLocal"
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -79,9 +60,9 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -103,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -120,7 +101,7 @@ jobs:
           ./gradlew publishToMavenLocal
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -26,14 +26,15 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout Skills
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ dependencies {
     compileOnly("com.google.guava:guava:33.2.1-jre")
     compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: '3.16.0'
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.12.0'
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
 
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"

--- a/src/main/java/org/opensearch/agent/tools/RAGTool.java
+++ b/src/main/java/org/opensearch/agent/tools/RAGTool.java
@@ -113,6 +113,7 @@ public class RAGTool implements Tool {
             T queryToolOutput;
             if (!this.enableContentGeneration) {
                 listener.onResponse(r);
+                return;
             }
             if (r.equals("Can not get any match from search result.")) {
                 queryToolOutput = (T) "";

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -91,9 +91,12 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
     @SneakyThrows
     private Map<String, Object> parseResponseToMap(Response response) {
         String responseBody = EntityUtils.toString(response.getEntity());
-        logger.info("responseBody: {}", responseBody);
-        Map<String, Object> responseInMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
-        return responseInMap;
+        try {
+            return XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+        } catch (Exception e) {
+            logger.error("failed to parse response to map: {}", responseBody, e);
+            return Collections.emptyMap();
+        }
     }
 
     @SneakyThrows
@@ -338,8 +341,11 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
 
     // execute the agent, and return the String response from the json structure
     // {"inference_results": [{"output": [{"name": "response","result": "the result to return."}]}]}
+    @SneakyThrows
     public String executeAgent(String agentId, String requestBody) {
         Response response = makeRequest(client(), "POST", "/_plugins/_ml/agents/" + agentId + "/_execute", null, requestBody, null);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        logger.info("responseBody for agent execution: {}, agentId: {}", responseBody, agentId);
         return parseStringResponseFromExecuteAgentResponse(response);
     }
 

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -49,6 +49,7 @@ import com.google.gson.Gson;
 
 import lombok.SneakyThrows;
 
+
 public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
     public static final Gson gson = new Gson();
     private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
@@ -90,8 +91,10 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     private Map<String, Object> parseResponseToMap(Response response) {
+        String responseBody= EntityUtils.toString(response.getEntity());
+        logger.info("responseBody: {}", responseBody);
         Map<String, Object> responseInMap = XContentHelper
-            .convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+            .convertToMap(XContentType.JSON.xContent(), responseBody, false);
         return responseInMap;
     }
 

--- a/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
+++ b/src/test/java/org/opensearch/integTest/BaseAgentToolsIT.java
@@ -49,7 +49,6 @@ import com.google.gson.Gson;
 
 import lombok.SneakyThrows;
 
-
 public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
     public static final Gson gson = new Gson();
     private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
@@ -91,10 +90,9 @@ public abstract class BaseAgentToolsIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     private Map<String, Object> parseResponseToMap(Response response) {
-        String responseBody= EntityUtils.toString(response.getEntity());
+        String responseBody = EntityUtils.toString(response.getEntity());
         logger.info("responseBody: {}", responseBody);
-        Map<String, Object> responseInMap = XContentHelper
-            .convertToMap(XContentType.JSON.xContent(), responseBody, false);
+        Map<String, Object> responseInMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
         return responseInMap;
     }
 


### PR DESCRIPTION
### Description
- [x] Fix github actions failure for linux 

```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node[20](https://github.com/opensearch-project/skills/actions/runs/12706385785/job/35419257910#step:3:21)/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```

- [x] Fix missing return for RAGTool


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
