### PR TITLE
Add Hailong Cui as skills Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,5 +23,6 @@
 | Subhobrata DEY        | [sbcd90](https://github.com/sbcd90)                 | Amazon      |
 | Zhichao Geng          | [zhichao-aws](https://github.com/zhichao-aws)       | Amazon      |
 | Joshua Li             | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Hailong Cui             | [hailong-am](https://github.com/hailong-am)       | Amazon      |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
### Description
Following the process at https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer, I have nominated and other maintainers have agreed to add Hailong Cui (@Hailong-am) as a co-Maintainer of the skills repository. Hailong has kindly accepted the invitation.

Hailong has been a long-time and consistent contributor to skills since the repo was created. 

He built the visualization tool:
https://github.com/opensearch-project/skills/pull/41 

He built the painless script tool:
https://github.com/opensearch-project/skills/pull/380 

He set up the mocked http server for integ test framework. The http server is used as mocked LLM endpoint by other tools in the repo:
https://github.com/opensearch-project/skills/pull/92 

He also actively fixed flaky tests, build errors and CI scripts:
https://github.com/opensearch-project/skills/pull/69 
https://github.com/opensearch-project/skills/pull/70 
https://github.com/opensearch-project/skills/pull/114 
https://github.com/opensearch-project/skills/pull/173 
https://github.com/opensearch-project/skills/pull/316 
https://github.com/opensearch-project/skills/pull/477 

I believe Hailong has already been participating as much or more than many maintainers and would be a valuable addition to the maintainer team.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
