### PR TITLE
Sync maintainers list between main and 2.x

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,5 +22,8 @@
 | Surya Sashank Nistala | [eirsep](https://github.com/eirsep)                 | Amazon      |
 | Subhobrata DEY        | [sbcd90](https://github.com/sbcd90)                 | Amazon      |
 | Zhichao Geng          | [zhichao-aws](https://github.com/zhichao-aws)       | Amazon      |
+| Joshua Li             | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Binlong Gao           | [gaobinlong](https://github.com/gaobinlong)         | Amazon      |
+| Hailong Cui             | [hailong-am](https://github.com/hailong-am)       | Amazon      |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
### Description
back port #484 #485 ; sync maintainers list

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
