### PR TITLE
Fix CVE caused by jetty-http introduced in spark-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,8 @@ task addSparkJar(type: Copy) {
         }
         // Remove the unwanted directory from jar B
         delete file("${jarBContents}/org/apache/spark/unused")
-
+        delete file("${jarBContents}/org/sparkproject/jetty/http")
+        delete file("${jarBContents}/META-INF/maven/org.eclipse.jetty/jetty-http")
         // Re-compress jar B
         ant.zip(destfile: jarB, baseDir: jarBContents)
 


### PR DESCRIPTION
### Description
Spark-core depends on jetty-http which has CVE: https://avd.aquasec.com/nvd/cve-2024-6763, but spark doesn't have a version that fixed this, so removing this dependency manually in build.gradle, we need to test the features used spark-core before merging this PR.

### Related Issues
https://github.com/opensearch-project/skills/issues/454

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
