### PR TITLE
Fix jar hell for sql jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     compileOnly group: 'org.opensearch', name:'opensearch-ml-spi', version: "${opensearch_build}"
     compileOnly fileTree(dir: jsJarDirectory, include: ["opensearch-job-scheduler-${opensearch_build}.jar"])
     implementation fileTree(dir: adJarDirectory, include: ["opensearch-anomaly-detection-${opensearch_build}.jar"])
-    implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-${opensearch_build}.jar", "ppl-${opensearch_build}.jar", "protocol-${opensearch_build}.jar"])
+    implementation fileTree(dir: sqlJarDirectory, include: ["opensearch-sql-thin-${opensearch_build}.jar", "ppl-${opensearch_build}.jar", "protocol-${opensearch_build}.jar"])
     implementation fileTree(dir: sparkDir, include: ["spark*.jar"])
     compileOnly "org.opensearch:common-utils:${opensearch_build}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
@@ -264,11 +264,10 @@ task extractSqlClass(type: Copy, dependsOn: [extractSqlJar]) {
 
 task replaceSqlJar(type: Jar, dependsOn: [extractSqlClass]) {
     from("$buildDir/opensearch-sql")
-    archiveFileName = "opensearch-sql-thin.jar"
+    archiveFileName = "opensearch-sql-thin-${opensearch_build}.jar"
     destinationDirectory = file(sqlJarDirectory)
     doLast {
         file("${sqlJarDirectory}/opensearch-sql-${opensearch_build}.jar").delete()
-        file("${sqlJarDirectory}/opensearch-sql-thin.jar").renameTo("${sqlJarDirectory}/opensearch-sql-${opensearch_build}.jar")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,22 @@ task extractSqlJar(type: Copy) {
     from(zipTree(configurations.zipArchive.find { it.name.startsWith("opensearch-sql-plugin")}))
     into sqlJarDirectory
 }
+task extractSqlClass(type: Copy, dependsOn: [extractSqlJar]) {
+    from zipTree("${sqlJarDirectory}/opensearch-sql-${opensearch_build}.jar")
+    into("$buildDir/opensearch-sql")
+    include 'org/opensearch/sql/**'
+}
+
+task replaceSqlJar(type: Jar, dependsOn: [extractSqlClass]) {
+    from("$buildDir/opensearch-sql")
+    archiveFileName = "opensearch-sql-thin.jar"
+    destinationDirectory = file(sqlJarDirectory)
+    doLast {
+        file("${sqlJarDirectory}/opensearch-sql-${opensearch_build}.jar").delete()
+        file("${sqlJarDirectory}/opensearch-sql-thin.jar").renameTo("${sqlJarDirectory}/opensearch-sql-${opensearch_build}.jar")
+    }
+}
+
 
 task extractJsJar(type: Copy) {
     mustRunAfter()
@@ -269,7 +285,7 @@ task extractAdJar(type: Copy) {
     into adJarDirectory
 }
 
-tasks.addJarsToClasspath.dependsOn(extractSqlJar)
+tasks.addJarsToClasspath.dependsOn(replaceSqlJar)
 tasks.addJarsToClasspath.dependsOn(extractJsJar)
 tasks.addJarsToClasspath.dependsOn(extractAdJar)
 tasks.addJarsToClasspath.dependsOn(addSparkJar)

--- a/src/test/java/org/opensearch/integTest/PPLToolIT.java
+++ b/src/test/java/org/opensearch/integTest/PPLToolIT.java
@@ -54,10 +54,10 @@ public class PPLToolIT extends ToolIntegrationTest {
         String agentId = registerAgent();
         String result = executeAgent(agentId, "{\"parameters\": {\"question\": \"correct\", \"index\": \"employee\"}}");
         assertEquals(
-            "{\"ppl\":\"source\\u003demployee| where age \\u003e 56 | stats COUNT() as cnt\"," +
-            "\"executionResult\":\"{\\n  \\\"schema\\\": [\\n    {\\n      \\\"name\\\": \\\"cnt\\\",\\n      " +
-            "\\\"type\\\": \\\"int\\\"\\n    }\\n  ],\\n  \\\"datarows\\\": [\\n    [\\n      0\\n    ]\\n  ],\\n  " +
-            "\\\"total\\\": 1,\\n  \\\"size\\\": 1\\n}\"}",
+            "{\"ppl\":\"source\\u003demployee| where age \\u003e 56 | stats COUNT() as cnt\","
+                + "\"executionResult\":\"{\\n  \\\"schema\\\": [\\n    {\\n      \\\"name\\\": \\\"cnt\\\",\\n      "
+                + "\\\"type\\\": \\\"int\\\"\\n    }\\n  ],\\n  \\\"datarows\\\": [\\n    [\\n      0\\n    ]\\n  ],\\n  "
+                + "\\\"total\\\": 1,\\n  \\\"size\\\": 1\\n}\"}",
             result
         );
     }

--- a/src/test/java/org/opensearch/integTest/PPLToolIT.java
+++ b/src/test/java/org/opensearch/integTest/PPLToolIT.java
@@ -54,7 +54,10 @@ public class PPLToolIT extends ToolIntegrationTest {
         String agentId = registerAgent();
         String result = executeAgent(agentId, "{\"parameters\": {\"question\": \"correct\", \"index\": \"employee\"}}");
         assertEquals(
-            "{\"ppl\":\"source\\u003demployee| where age \\u003e 56 | stats COUNT() as cnt\",\"executionResult\":\"{\\n  \\\"schema\\\": [\\n    {\\n      \\\"name\\\": \\\"cnt\\\",\\n      \\\"type\\\": \\\"integer\\\"\\n    }\\n  ],\\n  \\\"datarows\\\": [\\n    [\\n      0\\n    ]\\n  ],\\n  \\\"total\\\": 1,\\n  \\\"size\\\": 1\\n}\"}",
+            "{\"ppl\":\"source\\u003demployee| where age \\u003e 56 | stats COUNT() as cnt\"," +
+            "\"executionResult\":\"{\\n  \\\"schema\\\": [\\n    {\\n      \\\"name\\\": \\\"cnt\\\",\\n      " +
+            "\\\"type\\\": \\\"int\\\"\\n    }\\n  ],\\n  \\\"datarows\\\": [\\n    [\\n      0\\n    ]\\n  ],\\n  " +
+            "\\\"total\\\": 1,\\n  \\\"size\\\": 1\\n}\"}",
             result
         );
     }


### PR DESCRIPTION
### Description

To exclude other non sql related classes from opensearch-sql-xxx.jar to avoid jar hell. The actual sql execution will happed in sql plugin, we don't need to worry about missing any runtime dependencies for sql execution.

sql classes in skills repos are used for compilation and runtime type reference, not for any sql execution.

### Related Issues

https://github.com/opensearch-project/skills/pull/543#issuecomment-2773924634

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
