### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,14 @@ configurations {
             force("org.apache.httpcomponents.client5:httpclient5:5.4.1")
         }
     }
+    agent
 }
+
+dependencies { 
+   agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+   agent "org.opensearch:opensearch-agent:${opensearch_version}"
+   agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+ }
 
 task addJarsToClasspath(type: Copy) {
     from(fileTree(dir: sqlJarDirectory)) {
@@ -682,4 +689,14 @@ task updateVersion {
         // Include the required files that needs to be updated with new Version
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
+}
+
+task prepareAgent(type: Copy) {
+   from(configurations.agent)
+   into "$buildDir/agent"
+}
+ 
+tasks.withType(Test) {
+   dependsOn prepareAgent
+   jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }


### PR DESCRIPTION
### Description
Support phasing off SecurityManager usage in favor of Java Agent

This commit allows passing a JVM argument to allow plugins test execute under Java Agent.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
