### PR TITLE
fix json path error when parsing custom API response

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/WebSearchTool.java
+++ b/src/main/java/org/opensearch/agent/tools/WebSearchTool.java
@@ -233,7 +233,7 @@ public class WebSearchTool implements Tool {
                 parseBingResults(rawJson, nextPage, listener);
                 break;
             case "custom":
-                List<String> urls = JsonPath.read(rawJson, customResUrlJsonpath);
+                List<String> urls = JsonPath.read(rawResponse, customResUrlJsonpath);
                 parseCustomResults(urls, authorization, nextPage, listener);
                 break;
             default:


### PR DESCRIPTION
### Description
fix json path error when parsing custom API response

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
