### PR TITLE
Switch guava deps from compileOnly to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ dependencies {
 
     compileOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.23.1"
     compileOnly group: 'org.json', name: 'json', version: '20240303'
-    compileOnly("com.google.guava:guava:33.2.1-jre")
+    implementation("com.google.guava:guava:33.2.1-jre")
     compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: '3.16.0'
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.12.0'
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")


### PR DESCRIPTION
### Description

skills has its guava dependencies set at compileOnly level which means they are not packaged into the skills assembly and available at runtime. 

skills uses these deps at runtime, however, the way this works is because of the extending relationship between skills and JS plugin where the deps of the extended plugin are available to the extending plugin at runtime.

In https://github.com/opensearch-project/job-scheduler/pull/773, guava was removed from JS which means these deps are no longer available to skills at runtime. I'm creating this PR to change the guava deps from compileOnly to implementation to ensure they are included in the assembly and available at runtime.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
