### PR TITLE
fix fields bug

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -514,7 +514,7 @@ public class PPLTool implements WithModelTool {
             );
         }
         Map<String, String> fieldsToType = new HashMap<>();
-        ToolHelper.extractFieldNamesTypes(mappingSource, fieldsToType, "", false);
+        ToolHelper.extractFieldNamesTypes(mappingSource, fieldsToType, "", true);
         StringJoiner tableInfoJoiner = new StringJoiner("\n");
         List<String> sortedKeys = new ArrayList<>(fieldsToType.keySet());
         Collections.sort(sortedKeys);


### PR DESCRIPTION
### Description
For some fields keyword like 
```
{
    "a": {
   "type": "text",
   "fields": {
        "keyword": {"type": "keyword"}}
}
}
```
Now we allow model to accept a.keyword as another field since it may do aggregation on the original text field a, which is not allowed in PPL/DSL.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
