### PR TITLE
mask error message in PPLTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.spark.sql.types.DataType;
 import org.json.JSONObject;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.opensearch.action.search.SearchRequest;
@@ -262,8 +263,14 @@ public class PPLTool implements WithModelTool {
                     );
                 // Execute output here
             }, e -> {
+
                 log.error(String.format(Locale.ROOT, "fail to predict model: %s with error: %s", modelId, e.getMessage()), e);
-                listener.onFailure(e);
+                if (e instanceof OpenSearchStatusException) {
+                    String errorMessage = redactSagemakerArns(redactCloudwatchUrl(e.getMessage()));
+                    listener.onFailure(new OpenSearchStatusException(errorMessage, ((OpenSearchStatusException) e).status()));
+                } else {
+                    listener.onFailure(e);
+                }
             }));
         }, e -> {
             log.info("fail to get index schema");
@@ -685,5 +692,21 @@ public class PPLTool implements WithModelTool {
             log.error("Failed to load default prompt dict", e);
         }
         return new HashMap<>();
+    }
+
+    private static String redactSagemakerArns(String input) {
+        String regex = "arn:aws:logs:[^:]+:\\d+:log-group:/aws/sagemaker/Endpoints/[^ \\t\\n\\r\\f\\v,\"']+";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(input);
+
+        return matcher.replaceAll("<SAGEMAKER_ENDPOINT>");
+    }
+
+    public static String redactCloudwatchUrl(String input) {
+        String regex = "See\\s+.+?\\s+in\\s+account\\s+.+?\\s+for\\s+more\\s+information";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(input);
+
+        return matcher.replaceAll("");
     }
 }


### PR DESCRIPTION
### Description
Currently, the error message from sagemaker t2ppl endpoint will contain the account number with endpoint name.
Like {"ErrorCode":"CLIENT_ERROR_FROM_MODEL","LogStreamArn":"arn:aws:logs:us-east-1:<account_number>:log-group:/aws/sagemaker/Endpoints/endpoint_name","Message":"Received client error (404) from primary with message \"{\n \"code\":404,\n \"message\":\"prediction failure\",\n \"error\":\"Input token limit exceeded. The model only supports schemas with less than 1000-1500 fields, and has optimal performance for 350 fields or fewer.\"\n}\". See https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/sagemaker/Endpoints/endpoint_name in account <account_number> for more information.","OriginalMessage":"{\n \"code\":404,\n \"message\":\"prediction failure\",\n \"error\":\"Input token limit exceeded. The model only supports schemas with less than 1000-1500 fields, and has optimal performance for 350 fields or fewer.\"\n}","OriginalStatusCode":404}
 We need to mask it.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
