### PR TITLE
Update github CI to support java 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Build and Test
         run: |
+          ls -l /sys/fs/cgroup/memory.max
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew build &&
                                ./gradlew publishToMavenLocal"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     name: Build and Test skills plugin on Linux
     runs-on: ubuntu-latest
     container:
@@ -52,7 +52,7 @@ jobs:
   build-MacOS:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
 
     name: Build and Test skills Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -77,7 +77,7 @@ jobs:
   build-windows:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     name: Build and Test skills plugin on Windows
     needs: Get-CI-Image-Tag
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Build and Test
         run: |
-          ls -l /sys/fs/cgroup/memory.max
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew build &&
                                ./gradlew publishToMavenLocal"

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [21, 24]
+        java: [21, 23]
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     name: Run Security Integration Tests on Linux

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,7 +16,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     name: Run Security Integration Tests on Linux

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ plugins {
 }
 
 lombok {
-    version = "1.18.34"
+    version = "1.18.38"
 }
 
 repositories {


### PR DESCRIPTION
### Description
Update github CI to support java 24

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
