### PR TITLE
Add more information in ppl tool when passing to sagemaker

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -82,6 +82,8 @@ public class PPLTool implements WithModelTool {
 
     public static final String TYPE = "PPLTool";
 
+    public static final String NO_ESCAPE_PARAMS = "no_escape_params";
+
     @Setter
     private Client client;
 
@@ -249,7 +251,7 @@ public class PPLTool implements WithModelTool {
                 );
             RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
                 .builder()
-                .parameters(Map.of("prompt", gson.toJson(gson.toJson(reformattedInput))))
+                .parameters(Map.of("prompt", formatString(reformattedInput), NO_ESCAPE_PARAMS, "prompt"))
                 .build();
             ActionRequest request = new MLPredictionTaskRequest(
                 modelId,
@@ -747,5 +749,10 @@ public class PPLTool implements WithModelTool {
         Matcher matcher = pattern.matcher(input);
 
         return matcher.replaceAll("");
+    }
+
+    public String formatString(Map<String, Object> targetMap) {
+        String mapString = gson.toJson(gson.toJson(targetMap));
+        return mapString.substring(1, mapString.length() - 1);
     }
 }

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -233,7 +233,7 @@ public class PPLTool implements WithModelTool {
             }
         }
         ActionListener<Map<String, Object>> actionsAfterTableinfo = ActionListener.wrap(indexInfo -> {
-            if (!indexInfo.containsKey(TABLE_INFO_KEY) || !indexInfo.containsKey(MAPPING_KEY)) {
+            if (Objects.isNull(indexInfo.get(TABLE_INFO_KEY)) || Objects.isNull(indexInfo.get(MAPPING_KEY))) {
                 log.error("The table info and mappings are missing in: {}", indexInfo);
                 listener.onFailure(new RuntimeException("The table info and mappings are missing in: " + indexInfo));
             }

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -7,6 +7,7 @@ package org.opensearch.agent.tools;
 
 import static org.opensearch.agent.tools.utils.CommonConstants.COMMON_MODEL_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.utils.ToolUtils.NO_ESCAPE_PARAMS;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,8 +82,6 @@ import lombok.extern.log4j.Log4j2;
 public class PPLTool implements WithModelTool {
 
     public static final String TYPE = "PPLTool";
-
-    public static final String NO_ESCAPE_PARAMS = "no_escape_params";
 
     @Setter
     private Client client;

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -231,16 +231,15 @@ public class PPLTool implements WithModelTool {
                 );
             }
         }
-        ActionListener<Map<String, String>> actionsAfterTableinfo = ActionListener.wrap(indexInfo -> {
-            String tableInfo = indexInfo.get(TABLE_INFO_KEY);
-            String mappings = indexInfo.get(MAPPING_KEY);
+        ActionListener<Map<String, Object>> actionsAfterTableinfo = ActionListener.wrap(indexInfo -> {
+            String tableInfo = indexInfo.get(TABLE_INFO_KEY).toString();
             String prompt = constructPrompt(tableInfo, question.strip(), indices);
-            Map<String, String> reformattedInput = Map
+            Map<String, Object> reformattedInput = Map
                 .of(
                     "prompt",
                     prompt,
                     "mappings",
-                    mappings,
+                        indexInfo.get(MAPPING_KEY),
                     "os_version",
                     Version.CURRENT.toString(),
                     "current_time",
@@ -250,7 +249,7 @@ public class PPLTool implements WithModelTool {
                 );
             RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
                 .builder()
-                .parameters(Map.of("prompt", gson.toJson(reformattedInput)))
+                .parameters(Map.of("prompt", gson.toJson(gson.toJson(reformattedInput))))
                 .build();
             ActionRequest request = new MLPredictionTaskRequest(
                 modelId,
@@ -359,7 +358,7 @@ public class PPLTool implements WithModelTool {
                     latch.countDown();
                     if (latch.getCount() == 0) {
                         String mergedTableInfo = mergeTableInfo(tableInfos);
-                        actionsAfterTableinfo.onResponse(Map.of(TABLE_INFO_KEY, mergedTableInfo, MAPPING_KEY, gson.toJson(mappingInfos)));
+                        actionsAfterTableinfo.onResponse(Map.of(TABLE_INFO_KEY, mergedTableInfo, MAPPING_KEY, mappingInfos));
                     }
                 }, e -> {
                     log.error(String.format(Locale.ROOT, "fail to search model: %s with error: %s", modelId, e.getMessage()), e);

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -239,7 +239,7 @@ public class PPLTool implements WithModelTool {
                     "prompt",
                     prompt,
                     "mappings",
-                        indexInfo.get(MAPPING_KEY),
+                    indexInfo.get(MAPPING_KEY),
                     "os_version",
                     Version.CURRENT.toString(),
                     "current_time",

--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -372,7 +372,7 @@ public class PPLTool implements WithModelTool {
                     listener
                         .onFailure(
                             new IllegalArgumentException(
-                                "Return this final answer to human directly and do not use other tools: 'Please provide index name'. Please try to directly send this message to human to ask for index name"
+                                "Return this final answer to human directly and do not use other tools: 'Please provide the existing index name(s)'. Please try to directly send this message to human to ask for index name"
                             )
                         );
                 } else {

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
+import static org.opensearch.agent.tools.utils.CommonConstants.COMMON_MODEL_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
@@ -321,6 +322,18 @@ public class PPLToolTests {
                     assertEquals("source=demo| head 1", returnResults.get("ppl"));
                 }, e -> { log.info(e); })
             );
+
+    }
+
+    @Test
+    public void testTool_basic() {
+        PPLTool tool = PPLTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt", "previous_tool_name", "previousTool", "head", "-5"));
+        assertEquals(tool.getDescription(), PPLTool.Factory.getInstance().getDefaultDescription());
+        assertEquals(tool.getType(), PPLTool.Factory.getInstance().getDefaultType());
+        assertEquals(null, PPLTool.Factory.getInstance().getDefaultVersion());
+        assertEquals(List.of(COMMON_MODEL_ID_FIELD), PPLTool.Factory.getInstance().getAllModelKeys());
 
     }
 

--- a/src/test/java/org/opensearch/integTest/PPLToolIT.java
+++ b/src/test/java/org/opensearch/integTest/PPLToolIT.java
@@ -54,7 +54,7 @@ public class PPLToolIT extends ToolIntegrationTest {
         String agentId = registerAgent();
         String result = executeAgent(agentId, "{\"parameters\": {\"question\": \"correct\", \"index\": \"employee\"}}");
         assertEquals(
-            "{\"ppl\":\"source\\u003demployee| where age \\u003e 56 | stats COUNT() as cnt\","
+            "{\"ppl\":\"source\\u003demployee | where age \\u003e 56 | stats COUNT() as cnt\","
                 + "\"executionResult\":\"{\\n  \\\"schema\\\": [\\n    {\\n      \\\"name\\\": \\\"cnt\\\",\\n      "
                 + "\\\"type\\\": \\\"int\\\"\\n    }\\n  ],\\n  \\\"datarows\\\": [\\n    [\\n      0\\n    ]\\n  ],\\n  "
                 + "\\\"total\\\": 1,\\n  \\\"size\\\": 1\\n}\"}",


### PR DESCRIPTION
### Description
The PR add more information into the request body when passing to sagemaker part in PPLTool.
Now we contain all information into a mapping
```
{ 
"prompt": <original_prompt>, 
"mappings": <all mappings>, 
"current_time": <current_time>, 
"os_version": <os_version> 
}
```
And to keep BWC, we still the mappings into the request body with keyword "prompt"


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
