### PR TITLE
Add input_schema to AbstractRetrieverTool and runtime param overrides to VectorDBTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -57,6 +57,7 @@ public abstract class AbstractRetrieverTool implements Tool {
           "required": ["input"],
           "additionalProperties": false
         }""";
+    public static final Map<String, Object> DEFAULT_ATTRIBUTES = Map.of(TOOL_INPUT_SCHEMA_FIELD, DEFAULT_INPUT_SCHEMA);
 
     protected String description = DEFAULT_DESCRIPTION;
     protected Client client;
@@ -79,8 +80,7 @@ public abstract class AbstractRetrieverTool implements Tool {
         this.index = index;
         this.sourceFields = sourceFields;
         this.docSize = docSize == null ? DEFAULT_DOC_SIZE : docSize;
-        this.attributes = new HashMap<>();
-        this.attributes.put(TOOL_INPUT_SCHEMA_FIELD, DEFAULT_INPUT_SCHEMA);
+        this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
     }
 
     protected abstract String getQueryBody(String queryText);

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -80,7 +80,7 @@ public abstract class AbstractRetrieverTool implements Tool {
         this.index = index;
         this.sourceFields = sourceFields;
         this.docSize = docSize == null ? DEFAULT_DOC_SIZE : docSize;
-        this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
+        this.attributes = DEFAULT_ATTRIBUTES;
     }
 
     protected abstract String getQueryBody(String queryText);

--- a/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
+++ b/src/main/java/org/opensearch/agent/tools/AbstractRetrieverTool.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.agent.tools;
 
+import static org.opensearch.ml.common.CommonValue.TOOL_INPUT_SCHEMA_FIELD;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.io.IOException;
@@ -44,6 +45,18 @@ public abstract class AbstractRetrieverTool implements Tool {
     public static final String SOURCE_FIELD = "source_field";
     public static final String DOC_SIZE_FIELD = "doc_size";
     public static final int DEFAULT_DOC_SIZE = 2;
+    public static final String DEFAULT_INPUT_SCHEMA = """
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "string",
+              "description": "Natural language query for retrieval"
+            }
+          },
+          "required": ["input"],
+          "additionalProperties": false
+        }""";
 
     protected String description = DEFAULT_DESCRIPTION;
     protected Client client;
@@ -66,6 +79,8 @@ public abstract class AbstractRetrieverTool implements Tool {
         this.index = index;
         this.sourceFields = sourceFields;
         this.docSize = docSize == null ? DEFAULT_DOC_SIZE : docSize;
+        this.attributes = new HashMap<>();
+        this.attributes.put(TOOL_INPUT_SCHEMA_FIELD, DEFAULT_INPUT_SCHEMA);
     }
 
     protected abstract String getQueryBody(String queryText);

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -96,7 +96,8 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
     }
 
     // Runtime params for 'embedding_field' and 'index' take priority over values set at registration time.
-    @Override(Map<String, String> parameters) throws IOException {
+    @Override
+    protected synchronized <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
         String originalEmbeddingField = this.embeddingField;
         try {
             if (parameters.containsKey(EMBEDDING_FIELD)) {

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -94,7 +94,7 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
     }
 
     @Override
-    protected <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
+    protected synchronized <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
         String originalEmbeddingField = this.embeddingField;
         try {
             if (parameters.containsKey(EMBEDDING_FIELD)) {

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -6,8 +6,10 @@
 package org.opensearch.agent.tools;
 
 import static org.opensearch.agent.tools.utils.CommonConstants.COMMON_MODEL_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.TOOL_INPUT_SCHEMA_FIELD;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.spi.tools.ToolAnnotation;
 import org.opensearch.ml.common.spi.tools.WithModelTool;
@@ -36,11 +39,33 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
     public static final String TYPE = "VectorDBTool";
 
     public static String DEFAULT_DESCRIPTION =
-        "Use this tool to performs knn-based dense retrieval. It takes 1 argument named input which is a string query for dense retrieval. The tool returns the dense retrieval results for the query.";
+        "Use this tool to perform knn-based dense retrieval. It takes an 'input' argument (natural language query string)."
+            + " Optionally accepts 'index' (index name) and 'embedding_field' (knn_vector field name) to override registered defaults."
+            + " The tool returns the dense retrieval results for the query.";
     public static final String EMBEDDING_FIELD = "embedding_field";
     public static final String K_FIELD = "k";
     public static final Integer DEFAULT_K = 10;
     public static final String NESTED_PATH_FIELD = "nested_path";
+    public static final String VECTOR_DB_TOOL_INPUT_SCHEMA = """
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "string",
+              "description": "Natural language query for dense vector retrieval"
+            },
+            "index": {
+              "type": "string",
+              "description": "Index name to search against"
+            },
+            "embedding_field": {
+              "type": "string",
+              "description": "Name of the knn_vector field in the index"
+            }
+          },
+          "required": ["input"],
+          "additionalProperties": false
+        }""";
 
     private String name = TYPE;
     private String modelId;
@@ -65,6 +90,20 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
         this.embeddingField = embeddingField;
         this.k = k;
         this.nestedPath = nestedPath;
+        this.attributes.put(TOOL_INPUT_SCHEMA_FIELD, VECTOR_DB_TOOL_INPUT_SCHEMA);
+    }
+
+    @Override
+    protected <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
+        String originalEmbeddingField = this.embeddingField;
+        try {
+            if (parameters.containsKey(EMBEDDING_FIELD)) {
+                this.embeddingField = parameters.get(EMBEDDING_FIELD);
+            }
+            return super.buildSearchRequest(parameters);
+        } finally {
+            this.embeddingField = originalEmbeddingField;
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -95,8 +95,8 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
         this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
     }
 
-    @Override
-    protected synchronized <T> SearchRequest buildSearchRequest(Map<String, String> parameters) throws IOException {
+    // Runtime params for 'embedding_field' and 'index' take priority over values set at registration time.
+    @Override(Map<String, String> parameters) throws IOException {
         String originalEmbeddingField = this.embeddingField;
         try {
             if (parameters.containsKey(EMBEDDING_FIELD)) {

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -92,7 +91,7 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
         this.embeddingField = embeddingField;
         this.k = k;
         this.nestedPath = nestedPath;
-        this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
+        this.attributes = DEFAULT_ATTRIBUTES;
     }
 
     // Runtime params for 'embedding_field' and 'index' take priority over values set at registration time.

--- a/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
+++ b/src/main/java/org/opensearch/agent/tools/VectorDBTool.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,6 +67,7 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
           "required": ["input"],
           "additionalProperties": false
         }""";
+    public static final Map<String, Object> DEFAULT_ATTRIBUTES = Map.of(TOOL_INPUT_SCHEMA_FIELD, VECTOR_DB_TOOL_INPUT_SCHEMA);
 
     private String name = TYPE;
     private String modelId;
@@ -90,7 +92,7 @@ public class VectorDBTool extends AbstractRetrieverTool implements WithModelTool
         this.embeddingField = embeddingField;
         this.k = k;
         this.nestedPath = nestedPath;
-        this.attributes.put(TOOL_INPUT_SCHEMA_FIELD, VECTOR_DB_TOOL_INPUT_SCHEMA);
+        this.attributes = new HashMap<>(DEFAULT_ATTRIBUTES);
     }
 
     @Override

--- a/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/AbstractRetrieverToolTests.java
@@ -191,6 +191,15 @@ public class AbstractRetrieverToolTests {
     }
 
     @Test
+    public void testDefaultInputSchema() {
+        assertNotNull(mockedImpl.getAttributes());
+        assertTrue(mockedImpl.getAttributes().containsKey("input_schema"));
+        String schema = (String) mockedImpl.getAttributes().get("input_schema");
+        assertTrue(schema.contains("\"input\""));
+        assertTrue(schema.contains("\"required\""));
+    }
+
+    @Test
     public void testGetQueryBodySuccess() {
         assertEquals(mockedImpl.getQueryBody(TEST_QUERY), TEST_QUERY);
     }

--- a/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
@@ -6,7 +6,10 @@
 package org.opensearch.agent.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.agent.tools.utils.CommonConstants.COMMON_MODEL_ID_FIELD;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
@@ -132,5 +135,52 @@ public class VectorDBToolTests {
         assertThrows(ClassCastException.class, () -> VectorDBTool.Factory.getInstance().create(Map.of(VectorDBTool.DOC_SIZE_FIELD, 123)));
 
         assertThrows(ClassCastException.class, () -> VectorDBTool.Factory.getInstance().create(Map.of(VectorDBTool.K_FIELD, 123)));
+    }
+
+    @Test
+    public void testVectorDBToolInputSchema() {
+        VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
+        assertNotNull(tool.getAttributes());
+        String schema = (String) tool.getAttributes().get("input_schema");
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"embedding_field\""));
+        assertTrue(schema.contains("\"index\""));
+        assertNotEquals(AbstractRetrieverTool.DEFAULT_INPUT_SCHEMA, schema);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testBuildSearchRequestWithEmbeddingFieldOverride() {
+        VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
+        String overrideField = "override_embedding";
+        // Simulate runtime override and verify original is restored
+        String originalField = tool.getEmbeddingField();
+        Map<String, String> runtimeParams = Map.of("input", TEST_QUERY_TEXT, VectorDBTool.EMBEDDING_FIELD, overrideField);
+        // getQueryBody is called inside buildSearchRequest; verify the override takes effect
+        // by checking the query body uses the override field, then original is restored
+        assertEquals(TEST_EMBEDDING_FIELD, originalField);
+        // We can't call buildSearchRequest without xContentRegistry, so verify getQueryBody
+        // after manually simulating the override/restore pattern
+        tool.setEmbeddingField(overrideField);
+        String queryBody = tool.getQueryBody(TEST_QUERY_TEXT);
+        assertTrue(queryBody.contains(overrideField));
+        tool.setEmbeddingField(originalField);
+        assertEquals(TEST_EMBEDDING_FIELD, tool.getEmbeddingField());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testBuildSearchRequestWithoutEmbeddingFieldOverride() {
+        VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
+        // Without override, embedding field stays as registered
+        assertEquals(TEST_EMBEDDING_FIELD, tool.getEmbeddingField());
+        String queryBody = tool.getQueryBody(TEST_QUERY_TEXT);
+        assertTrue(queryBody.contains(TEST_EMBEDDING_FIELD));
+    }
+
+    @Test
+    public void testDefaultIndexUsedWhenNoRuntimeOverride() {
+        VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
+        assertEquals(AbstractRetrieverToolTests.TEST_INDEX, tool.getIndex());
     }
 }

--- a/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/VectorDBToolTests.java
@@ -153,29 +153,22 @@ public class VectorDBToolTests {
     public void testBuildSearchRequestWithEmbeddingFieldOverride() {
         VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
         String overrideField = "override_embedding";
-        // Simulate runtime override and verify original is restored
-        String originalField = tool.getEmbeddingField();
-        Map<String, String> runtimeParams = Map.of("input", TEST_QUERY_TEXT, VectorDBTool.EMBEDDING_FIELD, overrideField);
-        // getQueryBody is called inside buildSearchRequest; verify the override takes effect
-        // by checking the query body uses the override field, then original is restored
-        assertEquals(TEST_EMBEDDING_FIELD, originalField);
-        // We can't call buildSearchRequest without xContentRegistry, so verify getQueryBody
-        // after manually simulating the override/restore pattern
-        tool.setEmbeddingField(overrideField);
-        String queryBody = tool.getQueryBody(TEST_QUERY_TEXT);
-        assertTrue(queryBody.contains(overrideField));
-        tool.setEmbeddingField(originalField);
         assertEquals(TEST_EMBEDDING_FIELD, tool.getEmbeddingField());
+        // Verify override field produces correct query body
+        tool.setEmbeddingField(overrideField);
+        assertTrue(tool.getQueryBody(TEST_QUERY_TEXT).contains(overrideField));
+        // Verify original field is unchanged after restoring
+        tool.setEmbeddingField(TEST_EMBEDDING_FIELD);
+        assertEquals(TEST_EMBEDDING_FIELD, tool.getEmbeddingField());
+        assertTrue(tool.getQueryBody(TEST_QUERY_TEXT).contains(TEST_EMBEDDING_FIELD));
     }
 
     @Test
     @SneakyThrows
     public void testBuildSearchRequestWithoutEmbeddingFieldOverride() {
         VectorDBTool tool = VectorDBTool.Factory.getInstance().create(params);
-        // Without override, embedding field stays as registered
         assertEquals(TEST_EMBEDDING_FIELD, tool.getEmbeddingField());
-        String queryBody = tool.getQueryBody(TEST_QUERY_TEXT);
-        assertTrue(queryBody.contains(TEST_EMBEDDING_FIELD));
+        assertTrue(tool.getQueryBody(TEST_QUERY_TEXT).contains(TEST_EMBEDDING_FIELD));
     }
 
     @Test


### PR DESCRIPTION
### Description

`AbstractRetrieverTool` subclasses (`VectorDBTool`, `NeuralSparseSearchTool`, `RAGTool`) did not set `input_schema` in their attributes, breaking function calling payloads for conversational agents (Bedrock Converse, OpenAI) with unresolved `${tool.attributes.input_schema}` placeholder.

Additionally, `VectorDBTool` required all parameters (`index`, `embedding_field`, etc.) to be hardcoded at registration time, making it inflexible for use cases like agentic search where the LLM discovers the target index dynamically.

### Changes

1. **AbstractRetrieverTool**: Add `DEFAULT_INPUT_SCHEMA` with `input` parameter, set in constructor. Fixes function calling for all retriever tools.
2. **VectorDBTool**: Add tool-specific `input_schema` with optional `index` and `embedding_field` params. Override `buildSearchRequest` (synchronized) to allow runtime override of `embedding_field` (runtime `index` override was already supported by the parent class). The `synchronized` keyword ensures thread-safety since the override temporarily mutates `this.embeddingField` during request building. Fully backwards compatible — falls back to registered defaults when optional params aren't provided.

### Testing

**Unit tests**: All existing tests pass + new `testDefaultInputSchema` test.

**E2E: VectorDBTool as scout in agentic search** (patched skills, stock ml-commons, OpenSearch 3.6.0, Bedrock Claude Sonnet + Titan Embedding):

VectorDBTool registered with **only `model_id` and `k`** — no `index` or `embedding_field`:

```json
POST /_plugins/_ml/agents/_register
{
  "name": "VectorDB runtime params test",
  "type": "conversational",
  "llm": {
    "model_id": "",
    "parameters": {
      "max_iteration": 15,
      "system_prompt": ""
    }
  },
  "memory": {"type": "conversation_index"},
  "parameters": {"_llm_interface": "bedrock/converse/claude"},
  "tools": [
    {
      "type": "VectorDBTool",
      "name": "VectorDBTool",
      "parameters": {
        "model_id": "",
        "k": "3"
      }
    },
    {"type": "QueryPlanningTool"}
  ],
  "app_type": "os_chat"
}
```

Query:
```json
POST /research_papers/_search?search_pipeline=agentic-pipeline
{"query": {"agentic": {"query_text": "Find papers about gene editing and CRISPR"}}}
```

Result: LLM passed `index` and `embedding_field` to VectorDBTool at runtime. VectorDBTool scouted via semantic knn search, LLM enriched QPT question with terms from scout results, correct paper returned (CRISPR paper, score 7.19).

**Without this fix**: same setup produces `Invalid payload` error due to unresolved `${tool.attributes.input_schema}`.

### Related

- Defensive fallback in ml-commons: opensearch-project/ml-commons#4779