### PR TITLE
fix(deps): upgrade Apache Spark to 3.5.8 for CVE-2025-54920

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -46,7 +46,7 @@ jobs:
                                ./gradlew publishToMavenLocal"
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -61,9 +61,9 @@ jobs:
 
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -102,7 +102,7 @@ jobs:
           ./gradlew publishToMavenLocal
           
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout Skills
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -138,11 +138,11 @@ dependencies {
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
 
-    spark 'org.apache.spark:spark-sql-api_2.13:3.5.4'
-    spark ('org.apache.spark:spark-core_2.13:3.5.4') {
+    spark 'org.apache.spark:spark-sql-api_2.13:3.5.8'
+    spark ('org.apache.spark:spark-core_2.13:3.5.8') {
         exclude group: 'org.eclipse.jetty', module: 'jetty-server'
     }
-    spark group: 'org.apache.spark', name: 'spark-common-utils_2.13', version: '3.5.4'
+    spark group: 'org.apache.spark', name: 'spark-common-utils_2.13', version: '3.5.8'
 
     implementation 'org.scala-lang:scala-library:2.13.9'
     implementation group: 'org.antlr', name: 'antlr4-runtime', version: '4.9.3'
@@ -197,9 +197,9 @@ task addSparkJar(type: Copy) {
     into sparkDir
 
     doLast {
-        def jarA = file("$sparkDir/spark-sql-api_2.13-3.5.4.jar")
-        def jarB = file("$sparkDir/spark-core_2.13-3.5.4.jar")
-        def jarC = file("$sparkDir/spark-common-utils_2.13-3.5.4.jar")
+        def jarA = file("$sparkDir/spark-sql-api_2.13-3.5.8.jar")
+        def jarB = file("$sparkDir/spark-core_2.13-3.5.8.jar")
+        def jarC = file("$sparkDir/spark-common-utils_2.13-3.5.8.jar")
 
         // 3a. Extract jar A to manipulate it
         def jarAContents = file("$buildDir/tmp/JarAContents")


### PR DESCRIPTION
### Description
Upgrade Spark dependencies from 3.5.4 to 3.5.8 to address CVE-2025-54920, a high-severity (CVSS 8.8) Jackson deserialization vulnerability in the Spark History Web UI that allows remote code execution.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
