### PR TITLE
Use PPL to fetch sample data in PPLTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -42,13 +42,12 @@ import org.opensearch.OpenSearchStatusException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.opensearch.action.search.SearchRequest;
+import org.opensearch.agent.tools.utils.PPLExecuteHelper;
 import org.opensearch.agent.tools.utils.ToolHelper;
 import org.opensearch.agent.tools.utils.mergeMetaData.MergeRuleHelper;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
-import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
@@ -60,8 +59,6 @@ import org.opensearch.ml.common.spi.tools.WithModelTool;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.ml.common.utils.ToolUtils;
-import org.opensearch.search.SearchHit;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.plugin.transport.PPLQueryAction;
 import org.opensearch.sql.plugin.transport.TransportPPLQueryRequest;
 import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse;
@@ -344,15 +341,23 @@ public class PPLTool implements WithModelTool {
                     throw new IllegalArgumentException("No matching mapping with index name: " + index);
                 }
                 String firstIndexName = (String) mappings.keySet().toArray()[0];
-                SearchRequest searchRequest = buildSearchRequest(firstIndexName);
-                client.search(searchRequest, ActionListener.wrap(searchResponse -> {
-                    SearchHit[] searchHits = searchResponse.getHits().getHits();
-                    Map<String, Object> finalMappings = new HashMap<>();
-                    for (MappingMetadata mappingMetadata : mappings.values()) {
-                        Map<String, Object> mappingSource = (Map<String, Object>) mappingMetadata.getSourceAsMap().get("properties");
-                        MergeRuleHelper.merge(mappingSource, finalMappings);
+                // Merge all mapping metadata into a single field->type map. This does not depend on the
+                // sample data, so we compute it before fetching samples.
+                Map<String, Object> finalMappings = new HashMap<>();
+                for (MappingMetadata mappingMetadata : mappings.values()) {
+                    Map<String, Object> mappingSource = (Map<String, Object>) mappingMetadata.getSourceAsMap().get("properties");
+                    MergeRuleHelper.merge(mappingSource, finalMappings);
+                }
+                // Fetch one sample document via PPL instead of a DSL match_all search.
+                String samplePPL = "source=" + firstIndexName + " | head 1";
+                PPLExecuteHelper.executePPLAndParseResult(client, samplePPL, pplResult -> {
+                    Map<String, Object> sampleSource = extractSampleFromPPLResult(pplResult);
+                    try {
+                        return constructTableInfo(sampleSource, finalMappings);
+                    } catch (PrivilegedActionException e) {
+                        throw new RuntimeException("Failed to construct table info for index: " + firstIndexName, e);
                     }
-                    String tableInfo = constructTableInfo(searchHits, finalMappings);
+                }, ActionListener.wrap(tableInfo -> {
                     tableInfos.put(index, tableInfo);
                     mappingInfos.put(index, finalMappings);
                     latch.countDown();
@@ -361,7 +366,12 @@ public class PPLTool implements WithModelTool {
                         actionsAfterTableinfo.onResponse(Map.of(TABLE_INFO_KEY, mergedTableInfo, MAPPING_KEY, mappingInfos));
                     }
                 }, e -> {
-                    log.error(String.format(Locale.ROOT, "fail to search index: %s with error: %s", firstIndexName, e.getMessage()), e);
+                    log
+                        .error(
+                            String
+                                .format(Locale.ROOT, "fail to get sample data of index: %s with error: %s", firstIndexName, e.getMessage()),
+                            e
+                        );
                     listener.onFailure(e);
                 }));
             }, e -> {
@@ -452,13 +462,6 @@ public class PPLTool implements WithModelTool {
         public List<String> getAllModelKeys() {
             return List.of(COMMON_MODEL_ID_FIELD);
         }
-    }
-
-    private SearchRequest buildSearchRequest(String indexName) {
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.size(1).query(new MatchAllQueryBuilder());
-        // client;
-        return new SearchRequest(new String[] { indexName }, searchSourceBuilder);
     }
 
     private GetMappingsRequest buildGetMappingRequest(String indexName) {
@@ -565,7 +568,33 @@ public class PPLTool implements WithModelTool {
 
     }
 
-    private String constructTableInfo(SearchHit[] searchHits, Map<String, Object> allFields) throws PrivilegedActionException {
+    /**
+     * Converts a PPL jdbc result into a field-name -> value map representing one sample document.
+     * The jdbc result keeps column names in "schema" and values in "datarows" (aligned by position),
+     * e.g. schema=[{name:price},{name:category}] and datarows=[[29.99,"dresses"]]. This recombines
+     * them into {price: 29.99, category: "dresses"} so it can feed the existing sample-extraction logic.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractSampleFromPPLResult(Map<String, Object> pplResult) {
+        Map<String, Object> sampleSource = new HashMap<>();
+        // PPLExecuteHelper already validates that "datarows" is present and is a List before invoking
+        // this parser, so we can cast directly here.
+        List<Map<String, Object>> schema = (List<Map<String, Object>>) pplResult.get("schema");
+        List<List<Object>> datarows = (List<List<Object>>) pplResult.get("datarows");
+        if (datarows.isEmpty()) {
+            return sampleSource;
+        }
+        List<Object> firstRow = datarows.get(0);
+        for (int i = 0; i < schema.size() && i < firstRow.size(); i++) {
+            Object nameObj = schema.get(i).get("name");
+            if (nameObj != null) {
+                sampleSource.put(nameObj.toString(), firstRow.get(i));
+            }
+        }
+        return sampleSource;
+    }
+
+    private String constructTableInfo(Map<String, Object> sampleSource, Map<String, Object> allFields) throws PrivilegedActionException {
         Map<String, String> fieldsToType = new HashMap<>();
         ToolHelper.extractFieldNamesTypes(allFields, fieldsToType, "", false);
 
@@ -573,9 +602,7 @@ public class PPLTool implements WithModelTool {
         List<String> sortedKeys = new ArrayList<>(fieldsToType.keySet());
         Collections.sort(sortedKeys);
 
-        if (searchHits.length > 0) {
-            SearchHit hit = searchHits[0];
-            Map<String, Object> sampleSource = hit.getSourceAsMap();
+        if (sampleSource != null && !sampleSource.isEmpty()) {
             Map<String, String> fieldsToSample = new HashMap<>();
             for (String key : fieldsToType.keySet()) {
                 fieldsToSample.put(key, "");

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.agent.tools;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.agent.tools.utils.CommonConstants.COMMON_MODEL_ID_FIELD;
 import static org.opensearch.ml.common.CommonValue.ML_CONNECTOR_INDEX;
@@ -19,28 +21,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.lucene.search.TotalHits;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.bytes.BytesArray;
-import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.output.model.MLResultDataType;
 import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.transport.MLTaskResponse;
 import org.opensearch.ml.common.transport.prediction.MLPredictionTaskAction;
-import org.opensearch.search.SearchHit;
-import org.opensearch.search.SearchHits;
+import org.opensearch.ml.common.transport.prediction.MLPredictionTaskRequest;
 import org.opensearch.sql.plugin.transport.PPLQueryAction;
+import org.opensearch.sql.plugin.transport.TransportPPLQueryRequest;
 import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -65,14 +66,6 @@ public class PPLToolTests {
     private Map<String, MappingMetadata> mockedMappings;
     private Map<String, Object> indexMappings;
 
-    private SearchHits searchHits;
-
-    private SearchHit hit;
-    @Mock
-    private SearchResponse searchResponse;
-
-    private Map<String, Object> sampleMapping;
-
     @Mock
     private MLTaskResponse mlTaskResponse;
     @Mock
@@ -87,9 +80,18 @@ public class PPLToolTests {
     @Mock
     private TransportPPLQueryResponse transportPPLQueryResponse;
 
+    @Mock
+    private TransportPPLQueryResponse sampleQueryResponse;
+
     private String mockedIndexName = "demo";
 
     private String pplResult = "ppl result";
+
+    // jdbc-formatted PPL result used for the "source=demo | head 1" sample-fetch query. Mirrors the
+    // sample document the old DSL search returned: demoFields=111, demoNested.nest1=222, nest2=333.
+    private String samplePPLResult = "{\"schema\":[{\"name\":\"demoFields\",\"type\":\"text\"},"
+        + "{\"name\":\"demoNested.nest1\",\"type\":\"text\"},{\"name\":\"demoNested.nest2\",\"type\":\"text\"}],"
+        + "\"datarows\":[[\"111\",\"222\",\"333\"]],\"total\":1,\"size\":1}";
 
     @Before
     public void setup() {
@@ -107,25 +109,30 @@ public class PPLToolTests {
         }).when(indicesAdminClient).getMappings(any(), any());
         // mockedMappings (index name, mappingmetadata)
 
-        // search result
-
-        when(searchResponse.getHits()).thenReturn(searchHits);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocation.getArguments()[1];
-            listener.onResponse(searchResponse);
-            return null;
-        }).when(client).search(any(), any());
-
         initMLTensors();
 
+        // Sample data is now fetched via a PPL query (source=<index> | head 1) instead of a DSL
+        // search, so we mock client.execute(PPLQueryAction) and differentiate the two PPL calls by
+        // their query string: the sample-fetch query returns a jdbc result, while the final
+        // (LLM-generated) PPL execution returns the plain "ppl result".
         when(transportPPLQueryResponse.getResult()).thenReturn(pplResult);
+        when(sampleQueryResponse.getResult()).thenReturn(samplePPLResult);
 
         doAnswer(invocation -> {
+            TransportPPLQueryRequest request = (TransportPPLQueryRequest) invocation.getArguments()[1];
             ActionListener<TransportPPLQueryResponse> listener = (ActionListener<TransportPPLQueryResponse>) invocation.getArguments()[2];
-            listener.onResponse(transportPPLQueryResponse);
+            if (isSamplePPL(request.getRequest())) {
+                listener.onResponse(sampleQueryResponse);
+            } else {
+                listener.onResponse(transportPPLQueryResponse);
+            }
             return null;
         }).when(client).execute(eq(PPLQueryAction.INSTANCE), any(), any());
         PPLTool.Factory.getInstance().init(client);
+    }
+
+    private boolean isSamplePPL(String ppl) {
+        return ppl != null && ppl.startsWith("source=" + mockedIndexName + " | head 1");
     }
 
     @Test
@@ -180,6 +187,66 @@ public class PPLToolTests {
     }
 
     @Test
+    public void testTool_sampleResultMissingSchemaOrDatarows() {
+        // The sample-fetch PPL result has neither schema nor datarows; extractSampleFromPPLResult should
+        // return an empty sample and the run should still succeed (tableInfo just omits sample values).
+        when(sampleQueryResponse.getResult()).thenReturn("{\"total\":0,\"size\":0}");
+        PPLTool tool = PPLTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt", "head", "100"));
+        assertEquals(PPLTool.TYPE, tool.getName());
+
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
+            Map<String, String> returnResults = gson.fromJson(executePPLResult, Map.class);
+            assertEquals("ppl result", returnResults.get("executionResult"));
+            assertEquals("source=demo| head 1", returnResults.get("ppl"));
+        }, e -> { log.info(e); }));
+    }
+
+    @Test
+    public void testTool_sampleResultEmptyDatarows() {
+        // The sample-fetch PPL result has a schema but an empty datarows array; extractSampleFromPPLResult
+        // should return an empty sample and the run should still succeed.
+        when(sampleQueryResponse.getResult())
+            .thenReturn("{\"schema\":[{\"name\":\"demoFields\",\"type\":\"text\"}],\"datarows\":[],\"total\":0,\"size\":0}");
+        PPLTool tool = PPLTool.Factory
+            .getInstance()
+            .create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt", "head", "100"));
+        assertEquals(PPLTool.TYPE, tool.getName());
+
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
+            Map<String, String> returnResults = gson.fromJson(executePPLResult, Map.class);
+            assertEquals("ppl result", returnResults.get("executionResult"));
+            assertEquals("source=demo| head 1", returnResults.get("ppl"));
+        }, e -> { log.info(e); }));
+    }
+
+    @Test
+    public void testTool_sampleValuesFromPPLReachPrompt() {
+        // Using a prompt template that echoes the table info, the prompt sent to the LLM equals the
+        // constructed tableInfo. This verifies the sample values fetched via the PPL sample query
+        // (extractSampleFromPPLResult -> constructTableInfo) actually flow into the prompt.
+        PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "${indexInfo.mappingInfo}"));
+
+        ArgumentCaptor<MLPredictionTaskRequest> requestCaptor = ArgumentCaptor.forClass(MLPredictionTaskRequest.class);
+
+        tool
+            .run(
+                ImmutableMap.of("index", "demo", "question", "demo"),
+                ActionListener.<String>wrap(executePPLResult -> {}, e -> { log.info(e); })
+            );
+
+        verify(client).execute(eq(MLPredictionTaskAction.INSTANCE), requestCaptor.capture(), any());
+        RemoteInferenceInputDataSet inputDataSet = (RemoteInferenceInputDataSet) requestCaptor.getValue().getMlInput().getInputDataset();
+        String prompt = inputDataSet.getParameters().get("prompt");
+        // Sample values returned by the mocked sample PPL (datarows [["111","222","333"]]).
+        assertTrue(prompt.contains("demoFields"));
+        assertTrue(prompt.contains("111"));
+        assertTrue(prompt.contains("222"));
+        assertTrue(prompt.contains("333"));
+    }
+
+    @Test
     public void testToolWhenGettingSagemakerError() {
         PPLTool tool = PPLTool.Factory
             .getInstance()
@@ -195,18 +262,16 @@ public class PPLToolTests {
             listener.onFailure(exception);
             return null;
         }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
-        OpenSearchStatusException exception = assertThrows(
-            OpenSearchStatusException.class,
-            () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
-                Map<String, String> returnResults = gson.fromJson(executePPLResult, Map.class);
-                assertEquals("ppl result", returnResults.get("executionResult"));
-                assertEquals("source=demo| head 1", returnResults.get("ppl"));
-            }, e -> { throw new OpenSearchStatusException(e.getMessage(), ((OpenSearchStatusException) e).status()); }))
-        );
-        assertTrue(exception.getMessage().contains("<SAGEMAKER_ENDPOINT>"));
-        assertFalse(exception.getMessage().contains("demo-test-name"));
-        assertFalse(exception.getMessage().contains("12345678"));
-
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
+            fail("Should have failed with a redacted SageMaker error");
+        }, e -> {
+            // The redaction logic still runs; the redacted message propagates (wrapped by PPLExecuteHelper).
+            // We assert on the message content rather than the exception type, matching the pattern used
+            // in LogPatternAnalysisToolTests.
+            MatcherAssert.assertThat(e.getMessage(), containsString("<SAGEMAKER_ENDPOINT>"));
+            assertFalse(e.getMessage().contains("demo-test-name"));
+            assertFalse(e.getMessage().contains("12345678"));
+        }));
     }
 
     @Test
@@ -435,13 +500,9 @@ public class PPLToolTests {
         modelTensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, pplReturns);
         initMLTensors();
 
-        Exception exception = assertThrows(
-            IllegalStateException.class,
-            () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
-                assertEquals(pplResult, "ppl result");
-            }, e -> { throw new IllegalStateException(e.getMessage()); }))
-        );
-        assertEquals("Remote endpoint fails to inference.", exception.getMessage());
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+            fail("Should have failed when remote endpoint inference fails");
+        }, e -> MatcherAssert.assertThat(e.getMessage(), containsString("Remote endpoint fails to inference."))));
     }
 
     @Test
@@ -453,13 +514,9 @@ public class PPLToolTests {
         modelTensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, pplReturns);
         initMLTensors();
 
-        Exception exception = assertThrows(
-            IllegalStateException.class,
-            () -> tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
-                assertEquals(pplResult, "ppl result");
-            }, e -> { throw new IllegalStateException(e.getMessage()); }))
-        );
-        assertEquals("Remote endpoint fails to inference.", exception.getMessage());
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(ppl -> {
+            fail("Should have failed when remote endpoint returns null response");
+        }, e -> MatcherAssert.assertThat(e.getMessage(), containsString("Remote endpoint fails to inference."))));
     }
 
     @Test
@@ -559,21 +616,27 @@ public class PPLToolTests {
     }
 
     @Test
-    public void testTool_searchFailure() {
+    public void testTool_sampleFetchFailure() {
         PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
         assertEquals(PPLTool.TYPE, tool.getName());
-        Exception exception = new Exception("search error");
+        Exception exception = new Exception("sample error");
+        // Fail only the sample-fetch PPL query (source=demo | head 1); other PPL calls are unaffected.
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocation.getArguments()[1];
-            listener.onFailure(exception);
+            TransportPPLQueryRequest request = (TransportPPLQueryRequest) invocation.getArguments()[1];
+            ActionListener<TransportPPLQueryResponse> listener = (ActionListener<TransportPPLQueryResponse>) invocation.getArguments()[2];
+            if (isSamplePPL(request.getRequest())) {
+                listener.onFailure(exception);
+            } else {
+                listener.onResponse(transportPPLQueryResponse);
+            }
             return null;
-        }).when(client).search(any(), any());
+        }).when(client).execute(eq(PPLQueryAction.INSTANCE), any(), any());
 
         tool
             .run(
                 ImmutableMap.of("index", "demo", "question", "demo"),
                 ActionListener.<String>wrap(ppl -> { assertEquals(pplResult, "ppl result"); }, e -> {
-                    assertEquals("search error", e.getMessage());
+                    assertEquals("PPL execution failed: sample error", e.getMessage());
                 })
             );
     }
@@ -583,17 +646,24 @@ public class PPLToolTests {
         PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
         assertEquals(PPLTool.TYPE, tool.getName());
         Exception exception = new Exception("execute ppl error");
+        // Only fail the final (LLM-generated) PPL execution; the sample-fetch PPL must still succeed,
+        // otherwise the run never reaches the final execution we want to test here.
         doAnswer(invocation -> {
+            TransportPPLQueryRequest request = (TransportPPLQueryRequest) invocation.getArguments()[1];
             ActionListener<TransportPPLQueryResponse> listener = (ActionListener<TransportPPLQueryResponse>) invocation.getArguments()[2];
-            listener.onFailure(exception);
+            if (isSamplePPL(request.getRequest())) {
+                listener.onResponse(sampleQueryResponse);
+            } else {
+                listener.onFailure(exception);
+            }
             return null;
         }).when(client).execute(eq(PPLQueryAction.INSTANCE), any(), any());
 
         tool
             .run(
                 ImmutableMap.of("index", "demo", "question", "demo"),
-                ActionListener.<String>wrap(ppl -> { assertEquals(pplResult, "ppl result"); }, e -> {
-                    assertEquals("execute ppl:source=demo| head 1, get error: execute ppl error", e.getMessage());
+                ActionListener.<String>wrap(ppl -> fail("Should have failed when final PPL execution fails"), e -> {
+                    MatcherAssert.assertThat(e.getMessage(), containsString("execute ppl error"));
                 })
             );
     }
@@ -618,10 +688,6 @@ public class PPLToolTests {
         mockedMappings = new HashMap<>();
         mockedMappings.put(mockedIndexName, mappingMetadata);
 
-        BytesReference bytesArray = new BytesArray("{\"demoFields\":\"111\", \"demoNested\": {\"nest1\": \"222\", \"nest2\": \"333\"}}");
-        hit = new SearchHit(1);
-        hit.sourceRef(bytesArray);
-        searchHits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
         pplReturns = Collections.singletonMap("response", "source=demo| head 1");
         modelTensor = new ModelTensor("tensor", new Number[0], new long[0], MLResultDataType.STRING, null, null, pplReturns);
 


### PR DESCRIPTION
### Description
Use PPL to fetch sample data in `PPLTool` instead of a DSL `match_all` search.

Previously, `PPLTool` fetched a sample document via a DSL `match_all` search
(`client.search` with `MatchAllQueryBuilder`, size 1) to build the table info
that is fed into the LLM prompt. This change replaces that DSL search with a PPL
query (`source=<index> | head 1`) executed through `PPLExecuteHelper`, the shared
PPL execution utility already used by `LogPatternAnalysisTool`,
`DataDistributionTool`, and `DataFetchingHelper`.

This unifies sample retrieval with the existing PPL execution path (the final,
LLM-generated PPL is already run via PPL) and with the S3/Spark sample-handling
logic, and removes the OpenSearch-index-only DSL dependency for sample fetching.

Main changes:
- Replace the DSL `match_all` sample search with `PPLExecuteHelper.executePPLAndParseResult`
  using `source=<index> | head 1`.
- Add `extractSampleFromPPLResult` to recombine the PPL jdbc `schema` (column
  names) and `datarows` (values) into a field-name → value map, reusing the
  existing sample-extraction logic.
- Change `constructTableInfo` to accept the parsed sample map instead of `SearchHit[]`.
- Remove the now-unused `buildSearchRequest` method and the DSL-only imports
  (`SearchRequest`, `SearchSourceBuilder`, `MatchAllQueryBuilder`, `SearchHit`).

Tests:
- Update the existing `PPLToolTests` to mock the sample-fetch PPL query
  (`source=demo | head 1`) and differentiate it from the final PPL execution by
  query string, returning a jdbc-formatted result for the sample query.
- Add `testTool_sampleValuesFromPPLReachPrompt` to verify the sample values
  fetched via PPL actually flow into the prompt sent to the LLM.
- Adjust the error-path tests to assert on the exception **message** (matching the
  pattern used in `LogPatternAnalysisToolTests`) rather than the exact exception
  type, since errors now propagate through `PPLExecuteHelper`.

### Why the existing tests were updated

  The change replaces sample-data fetching in `PPLTool` from a DSL `match_all`
  search (`client.search`) to a PPL query run through `PPLExecuteHelper`
  (`client.execute(PPLQueryAction)`). Because every affected test exercises the
  sample-fetch step, both their mocking and their assertions had to be adjusted.
  The updates fall into two categories.

  #### Category 1: Mocking the sample-fetch path (happy-path tests)

  - **Before:** sample data was fetched via `client.search`, so the tests mocked
    `client.search` to return a `SearchResponse` / `SearchHit[]`.
  - **After:** sample data is fetched via `client.execute(PPLQueryAction)`, so the
    tests now mock the PPL execution instead.
  - Since the sample-fetch query and the final (LLM-generated) PPL execution now go
    through the **same** `PPLQueryAction`, the mock differentiates them by the PPL
    query string: the sample query (`source=demo | head 1`) returns a jdbc-formatted
    result, while the final execution returns the plain result.

  #### Category 2: Adjusting exception assertions (error-path tests)

  Affected tests: `testToolWhenGettingSagemakerError`,
  `testTool_withWrongEndpointInference`,
  `testTool_withWrongEndpointInferenceWithNullResponse`, `testTool_executePPLFailure`.

  - **Before:** these tests asserted on the exact exception **type**
    (`OpenSearchStatusException`, `IllegalStateException`).
  - **After:** errors now propagate through `PPLExecuteHelper`, which wraps them in a
    `RuntimeException`, so asserting the exact type no longer holds.
  - The tests were changed to assert on the exception **message** instead (e.g.
    `<SAGEMAKER_ENDPOINT>`, `Remote endpoint fails to inference.`), matching the
    pattern already used in `LogPatternAnalysisToolTests` for errors surfaced through
    `PPLExecuteHelper`.

  **No functional regression:** the SageMaker redaction logic still works — the
  redacted placeholder `<SAGEMAKER_ENDPOINT>` is present and the raw ARN / account ID
  are removed. The only change is that the exception type is now wrapped by
  `PPLExecuteHelper`, consistent with how other tools using the same helper behave.

### Updated error-path tests

  All four tests are in the same file: `src/test/java/org/opensearch/agent/tools/PPLToolTests.java`

  | Test | File | Purpose | Simulated failure | How it was changed |
  |----|----|-------------|-------------------|--------------------|
  | `testToolWhenGettingSagemakerError` | `PPLToolTests.java` | Verify that when SageMaker returns an error, sensitive info (ARN, account ID) is redacted | LLM call fails with an `OpenSearchStatusException` containing a SageMaker ARN | Assert the exception **message** contains `<SAGEMAKER_ENDPOINT>` and no longer contains the raw ARN / account ID, instead of asserting the exact exception type |
  | `testTool_withWrongEndpointInference` | `PPLToolTests.java` | Verify the tool reports an error when the LLM returns an error code instead of a PPL | `{"code":"424"}` (no `response` field) | Assert the exception message contains `"Remote endpoint fails to inference."` instead of asserting the exact exception type |
  | `testTool_withWrongEndpointInferenceWithNullResponse` | `PPLToolTests.java` | Verify the tool reports an error when the LLM returns a null response | `{"response": null}` | Same as above — assert the message contains `"Remote endpoint fails to inference."` |
  | `testTool_executePPLFailure` | `PPLToolTests.java` | Verify the tool reports an error when executing the final (LLM-generated) PPL fails | The final PPL execution throws an exception | Differentiate the two PPL calls via `isSamplePPL`: let the sample-fetch query succeed and only the final execution fail; assert the message contains `"execute ppl error"` |


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.