### PR TITLE
Sync CODEOWNERS with maintainer list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @xinyual @amitgalitz @jackiehanyang @owaiskazi19 @ohltyler @joshpalis @dbwiddis @kaituo @lezzago @eirsep @sbcd90 @zhichao-aws @joshuali925
+*   @b4sjoo @dhrubo-os @jngz-es @model-collapse @rbhavna @ylwu-amzn @zane-neo @Zhangxunmt @xinyual @amitgalitz @jackiehanyang @owaiskazi19 @ohltyler @joshpalis @dbwiddis @kaituo @lezzago @eirsep @sbcd90 @zhichao-aws @joshuali925 @hailong-am @gaobinlong


### PR DESCRIPTION
### Description
Add @hailong-am and @gaobinlong to CODEOWNERS to match the current MAINTAINERS.md list.

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/skills/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).