### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
     }
 
@@ -53,9 +54,9 @@ lombok {
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
-    maven { url "https://plugins.gradle.org/m2/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-skills'


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build.gradle` — Add CI mirror in buildscript and project repositories
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification