### PR TITLE
Force log4j-core to 2.25.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ configurations {
             force "org.mockito:mockito-core:${versions.mockito}"
             force "com.google.guava:guava:33.2.1-jre" // CVE for 31.1
             force("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") // CVE for < 3.29.0, forces JDK17 for spotless
+            force("org.apache.logging.log4j:log4j-core:2.25.4")
         }
     }
 }


### PR DESCRIPTION
### Description

Bumps `org.apache.logging.log4j:log4j-slf4j-impl` from 2.23.1 to 2.25.4 to address CVE-2026-34480, CVE-2026-34478, and CVE-2026-34477.

### Issues Resolved

Resolves log4j-core CVEs with vulnerable range `>=2.0-alpha1 <2.25.4`.