### PR TITLE
fix: Add null check for mapping properties in PPLTool

### DIFF
--- a/src/main/java/org/opensearch/agent/tools/PPLTool.java
+++ b/src/main/java/org/opensearch/agent/tools/PPLTool.java
@@ -346,7 +346,9 @@ public class PPLTool implements WithModelTool {
                 Map<String, Object> finalMappings = new HashMap<>();
                 for (MappingMetadata mappingMetadata : mappings.values()) {
                     Map<String, Object> mappingSource = (Map<String, Object>) mappingMetadata.getSourceAsMap().get("properties");
-                    MergeRuleHelper.merge(mappingSource, finalMappings);
+                    if (mappingSource != null && !mappingSource.isEmpty()) {
+                        MergeRuleHelper.merge(mappingSource, finalMappings);
+                    }
                 }
                 // Fetch one sample document via PPL instead of a DSL match_all search.
                 String samplePPL = "source=" + firstIndexName + " | head 1";

--- a/src/main/java/org/opensearch/agent/tools/utils/mergeMetaData/MergeRuleHelper.java
+++ b/src/main/java/org/opensearch/agent/tools/utils/mergeMetaData/MergeRuleHelper.java
@@ -23,6 +23,9 @@ public class MergeRuleHelper {
     }
 
     public static void merge(Map<String, Object> source, Map<String, Object> target) {
+        if (source == null || source.isEmpty()) {
+            return;
+        }
         for (Map.Entry<String, Object> entry : source.entrySet()) {
             String key = entry.getKey();
             Map<String, Object> sourceValue = (Map<String, Object>) entry.getValue();

--- a/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
+++ b/src/test/java/org/opensearch/agent/tools/PPLToolTests.java
@@ -668,6 +668,40 @@ public class PPLToolTests {
             );
     }
 
+    @Test
+    public void testTool_nullMappingProperties_doesNotThrowNPE() {
+        // Simulate an index that exists but has no "properties" in its mapping (returns null).
+        // This was the root cause of the NPE in MergeRuleHelper.merge() when
+        // mappingMetadata.getSourceAsMap().get("properties") returns null.
+        Map<String, Object> emptyMapping = new HashMap<>();
+        // No "properties" key at all — get("properties") returns null
+        when(mappingMetadata.getSourceAsMap()).thenReturn(emptyMapping);
+
+        PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
+
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
+            Map<String, String> returnResults = gson.fromJson(executePPLResult, Map.class);
+            assertEquals("ppl result", returnResults.get("executionResult"));
+            assertEquals("source=demo| head 1", returnResults.get("ppl"));
+        }, e -> { fail("Should not throw NPE when mapping has no properties: " + e.getMessage()); }));
+    }
+
+    @Test
+    public void testTool_emptyMappingProperties_doesNotThrowNPE() {
+        // Simulate an index where "properties" exists but is an empty map.
+        Map<String, Object> mappingWithEmptyProperties = new HashMap<>();
+        mappingWithEmptyProperties.put("properties", new HashMap<>());
+        when(mappingMetadata.getSourceAsMap()).thenReturn(mappingWithEmptyProperties);
+
+        PPLTool tool = PPLTool.Factory.getInstance().create(ImmutableMap.of("model_id", "modelId", "prompt", "contextPrompt"));
+
+        tool.run(ImmutableMap.of("index", "demo", "question", "demo"), ActionListener.<String>wrap(executePPLResult -> {
+            Map<String, String> returnResults = gson.fromJson(executePPLResult, Map.class);
+            assertEquals("ppl result", returnResults.get("executionResult"));
+            assertEquals("source=demo| head 1", returnResults.get("ppl"));
+        }, e -> { fail("Should not throw NPE when mapping properties is empty: " + e.getMessage()); }));
+    }
+
     private void createMappings() {
         indexMappings = new HashMap<>();
         indexMappings

--- a/src/test/java/org/opensearch/agent/tools/utils/mergeMetaData/MergeRuleHelperTests.java
+++ b/src/test/java/org/opensearch/agent/tools/utils/mergeMetaData/MergeRuleHelperTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.agent.tools.utils.mergeMetaData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class MergeRuleHelperTests {
+
+    @Test
+    public void testMerge_nullSource_doesNotThrow() {
+        Map<String, Object> target = new HashMap<>();
+        target.put("field1", Map.of("type", "text"));
+
+        MergeRuleHelper.merge(null, target);
+
+        // Target remains unchanged
+        assertEquals(1, target.size());
+        assertEquals(Map.of("type", "text"), target.get("field1"));
+    }
+
+    @Test
+    public void testMerge_emptySource_doesNotThrow() {
+        Map<String, Object> target = new HashMap<>();
+        target.put("field1", Map.of("type", "text"));
+
+        MergeRuleHelper.merge(new HashMap<>(), target);
+
+        // Target remains unchanged
+        assertEquals(1, target.size());
+        assertEquals(Map.of("type", "text"), target.get("field1"));
+    }
+
+    @Test
+    public void testMerge_emptySource_emptyTarget() {
+        Map<String, Object> target = new HashMap<>();
+
+        MergeRuleHelper.merge(new HashMap<>(), target);
+
+        assertTrue(target.isEmpty());
+    }
+
+    @Test
+    public void testMerge_nullSource_emptyTarget() {
+        Map<String, Object> target = new HashMap<>();
+
+        MergeRuleHelper.merge(null, target);
+
+        assertTrue(target.isEmpty());
+    }
+
+    @Test
+    public void testMerge_validSource_mergesIntoTarget() {
+        Map<String, Object> source = new HashMap<>();
+        source.put("field1", Map.of("type", "text"));
+
+        Map<String, Object> target = new HashMap<>();
+
+        MergeRuleHelper.merge(source, target);
+
+        assertEquals(1, target.size());
+        assertTrue(target.containsKey("field1"));
+    }
+}


### PR DESCRIPTION
### Description

Prevent a `NullPointerException` in `PPLTool` when `getMappings()` returns an index that exists but has no `properties` in its mapping. This happens when a query targets an index pattern (e.g. `observability-otel-metrics-prod-*`) that matches indices with empty mappings.

**Root cause:** `mappingMetadata.getSourceAsMap().get("properties")` returns `null` when the index has no `properties`. `MergeRuleHelper.merge()` then calls `source.entrySet()` on the null map, throwing an NPE and surfacing as a 500.

**Changes:**
- `PPLTool.java` — skip the merge when `mappingSource` is null/empty before calling `MergeRuleHelper.merge()`.
- `MergeRuleHelper.java` — defensive early return in `merge()` when `source` is null/empty.
- `MergeRuleHelperTests.java` (new) — unit tests covering null, empty, and valid source maps.
- `PPLToolTests.java` — tests for null and empty mapping-properties scenarios.

No behavioral change for indices that have valid mappings.

### Related Issues
<!-- No tracking issue -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.