### PR TITLE
Use Eclipse P2 mirror (skills)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,7 +351,7 @@ spotless {
             removeUnusedImports()
             importOrder 'java', 'javax', 'org', 'com'
             licenseHeaderFile 'spotless.license.java'
-            eclipse().configFile rootProject.file('.eclipseformat.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
         }
     } else {
         logger.lifecycle("Spotless plugin requires Java 17 or higher. Skipping Spotless tasks.")


### PR DESCRIPTION
Routes Spotless Eclipse P2 downloads through https://ci.opensearch.org/ to avoid direct download.eclipse.org outages.

Tracking bulletin: https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726