### PR TITLE
Bump 1password/load-secrets-action to v5.0.1 (skills)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Load secret
-        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           # Export loaded secrets as environment variables
           export-env: true


### PR DESCRIPTION
### Description
Bump `1password/load-secrets-action` to v5.0.1 (pinned to commit `70062d7a876d3eb6334754fa26efd2fbd90c32f2`).

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6440#issuecomment-5349573946

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
