### PR TITLE
Remove vulnerable shaded Jetty components for CVE-2026-10050

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,8 +253,12 @@ task addSparkJar(type: Copy) {
         delete file("${jarBContents}/org/apache/spark/unused")
         delete file("${jarBContents}/org/sparkproject/jetty/http")
         delete file("${jarBContents}/org/sparkproject/jetty/server")
+        delete file("${jarBContents}/org/sparkproject/jetty/security")
+        delete file("${jarBContents}/org/sparkproject/jetty/client")
         delete file("${jarBContents}/META-INF/maven/org.eclipse.jetty/jetty-http")
         delete file("${jarBContents}/META-INF/maven/org.eclipse.jetty/jetty-server")
+        delete file("${jarBContents}/META-INF/maven/org.eclipse.jetty/jetty-security")
+        delete file("${jarBContents}/META-INF/maven/org.eclipse.jetty/jetty-client")
         // Re-compress jar B
         ant.zip(destfile: jarB, baseDir: jarBContents)
 


### PR DESCRIPTION
## Description

Removes the shaded Jetty Security and Client classes, along with their Maven metadata, from the Spark Core JAR prepared by `addSparkJar`.

Spark 3.5.8 embeds Jetty 9.4.58, and `jetty-security` versions through 9.4.62 are affected by CVE-2026-10050. The build already removes the shaded Jetty HTTP and Server packages; Client and Security are not required by the plugin’s Spark SQL datatype usage and depend on those already-removed packages.

## Changes

- Remove `org/sparkproject/jetty/security` from the repackaged Spark Core JAR
- Remove `org/sparkproject/jetty/client` from the repackaged Spark Core JAR
- Remove matching `jetty-security` and `jetty-client` Maven metadata

## Validation

- `./gradlew clean addSparkJar`
- Verified the transformed Spark Core JAR contains no Jetty Client/Security classes or Maven metadata
- `./gradlew test`