### PR TITLE
Bump jsoup to address CVE-2026-71497

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-scala_3:${versions.jackson}"
     implementation group: 'org.scala-lang', name: 'scala3-library_3', version: '3.7.0-RC1-bin-20250119-bd699fc-NIGHTLY'
     implementation("com.thoughtworks.paranamer:paranamer:2.8")
-    implementation("org.jsoup:jsoup:1.19.1")
+    implementation("org.jsoup:jsoup:1.23.1")
 
     // Plugin dependencies
     compileOnly group: 'org.opensearch', name:'opensearch-ml-common', version: "${opensearch_build}"


### PR DESCRIPTION
### Description
Updates the Skills-owned `org.jsoup:jsoup` dependency from 1.19.1 to 1.23.1 to address CVE-2026-71497 from security advisory P508439181.

OpenSearch-managed dependencies continue to use the versions supplied by OpenSearch core and are not overridden by this PR.

jsoup is required by `WebSearchTool` for fetching and parsing web pages.

### Validation
- `./gradlew compileJava`
- Build succeeded with JDK 21